### PR TITLE
Add validation and documentation to VAE tiling.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2541,13 +2541,27 @@ class WanVideoDecode:
         return {"required": {
                     "vae": ("WANVAE",),
                     "samples": ("LATENT",),
-                    "enable_vae_tiling": ("BOOLEAN", {"default": False, "tooltip": "Drastically reduces memory use but may introduce seams"}),
-                    "tile_x": ("INT", {"default": 272, "min": 64, "max": 2048, "step": 1, "tooltip": "Tile size in pixels, smaller values use less VRAM, may introduce more seams"}),
-                    "tile_y": ("INT", {"default": 272, "min": 64, "max": 2048, "step": 1, "tooltip": "Tile size in pixels, smaller values use less VRAM, may introduce more seams"}),
-                    "tile_stride_x": ("INT", {"default": 144, "min": 32, "max": 2048, "step": 32, "tooltip": "Tile stride in pixels, smaller values use less VRAM, may introduce more seams"}),
-                    "tile_stride_y": ("INT", {"default": 128, "min": 32, "max": 2048, "step": 32, "tooltip": "Tile stride in pixels, smaller values use less VRAM, may introduce more seams"}),
+                    "enable_vae_tiling": ("BOOLEAN", {"default": False, "tooltip": (
+                        "Drastically reduces memory use but will introduce seams at tile stride boundaries. "
+                        "The location and number of seams is dictated by the tile stride size. "
+                        "The visibility of seams can be controlled by increasing the tile size. "
+                        "Seams become less obvious at 1.5x stride and are barely noticeable at 2x stride size. "
+                        "Which is to say if you use a stride width of 160, the seams are barely noticeable with a tile width of 320."
+                    )}),
+                    "tile_x": ("INT", {"default": 272, "min": 40, "max": 2048, "step": 8, "tooltip": "Tile width in pixels. Smaller values use less VRAM but will make seams more obvious."}),
+                    "tile_y": ("INT", {"default": 272, "min": 40, "max": 2048, "step": 8, "tooltip": "Tile height in pixels. Smaller values use less VRAM but will make seams more obvious."}),
+                    "tile_stride_x": ("INT", {"default": 144, "min": 32, "max": 2040, "step": 8, "tooltip": "Tile stride width in pixels. Smaller values use less VRAM but will introduce more seams."}),
+                    "tile_stride_y": ("INT", {"default": 128, "min": 32, "max": 2040, "step": 8, "tooltip": "Tile stride height in pixels. Smaller values use less VRAM but will introduce more seams."}),
                     },
                 }
+
+    @classmethod
+    def VALIDATE_INPUTS(s, tile_x, tile_y, tile_stride_x, tile_stride_y):
+        if tile_x <= tile_stride_x:
+            return "Tile width must be larger than the tile stride width."
+        if tile_y <= tile_stride_y:
+            return "Tile height must be larger than the tile stride height."
+        return True
 
     RETURN_TYPES = ("IMAGE",)
     RETURN_NAMES = ("images",)


### PR DESCRIPTION
Like I mentioned in #350 I got an error with VAE tiling since the latest fix in 0cf1330928512397134201ac192597466b3a2198. This motivated me to actually read the code in `nodes.py` and `wan_video_vae.py` to understand how this tiling is supposed to work. Now that I have a better understanding of how it works it makes sense to also improve the documentation for VAE tiling so that others can get a better grasp on this without having to dig through the code themselves.

---

First, there are a couple of rules that need to be upheld. Currently failing to follow these rules will cause an error at the end of running the workflow, just when the VAE tiling is supposed to happen. In this PR I added a validation check to error out at the beginning so that people don't waste time trying to run bad settings.

The first rule is that the tile size can't be smaller than the tile stride size. This is fundamentally expected in `wan_video_vae.py` where if the tile size is smaller, that difference will just be skipped completely - which is clearly not good behavior.

```python
for h in range(0, H, stride_h):
    if (h-stride_h >= 0 and h-stride_h+size_h >= H): continue
    for w in range(0, W, stride_w):
        if (w-stride_w >= 0 and w-stride_w+size_w >= W): continue
        h_, w_ = h + size_h, w + size_w
        tasks.append((h, h_, w, w_))
```

The second rule is that the tile size can't be equal to the stride size either. I'm not sure this is a fundamental requirement, but it is a de facto requirement of `wan_video_vae.py` right now. Using an equal tile size and stride size will just result in an error, e.g. `The expanded size of the tensor (160) must match the existing size (0) at non-singleton dimension 0.`

Thus to satisfy both of these rules we need to make sure that the tile size is always larger than the stride size. This PR adds a `VALIDATE_INPUTS` class method to make sure this is true before the workflow execution starts.

---

Both the tile size and stride size in pixels are expected by the code to be a multiple of 8. This PR adjusts the `step` on the node inputs to match the UI with this backend reality.

---

I rewrote the tooltips to add more detailed info based on my new understanding from reading the code and from inspecting a bunch of tiled test runs.

The key points are:
* Seams will definitely happen, it's just a question of how many and how obviously visible they are.
* The stride size determines the number and location of seams.
* The tile size determines how obviously visible the seams are. I found that a tile size of 1.5x stride already achieves invisibility for a quick glance and that 2x stride is barely noticable - requiring me to really zoom in at known seam location coordinates.

---

Closes #350