### PR TITLE
Load clip vision models from the `clip_vision` folder.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -940,7 +940,7 @@ class LoadWanVideoClipTextEncoder:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "model_name": (folder_paths.get_filename_list("clip_vision"), {"tooltip": "These models are loaded from 'ComfyUI/models/clip_vision'"}),
+                "model_name": (folder_paths.get_filename_list("clip_vision") + folder_paths.get_filename_list("text_encoders"), {"tooltip": "These models are loaded from 'ComfyUI/models/clip_vision'"}),
                  "precision": (["fp16", "fp32", "bf16"],
                     {"default": "fp16"}
                 ),
@@ -949,18 +949,6 @@ class LoadWanVideoClipTextEncoder:
                 "load_device": (["main_device", "offload_device"], {"default": "offload_device"}),
             }
         }
-
-    @classmethod
-    def VALIDATE_INPUTS(s, model_name):
-        # By default we expect the model file to be in the clip_vision folder
-        clip_vision_list = folder_paths.get_filename_list("clip_vision")
-        if model_name not in clip_vision_list:
-            # However, we also support legacy setups where the model is in the text_encoders folder
-            text_encoders_list = folder_paths.get_filename_list("text_encoders")
-            if model_name not in text_encoders_list:
-                # If we still can't find the model, then only mention the clip_vision contents in the error.
-                return f"'{model_name}' not in {clip_vision_list}"
-        return True
 
     RETURN_TYPES = ("CLIP_VISION",) 
     RETURN_NAMES = ("wan_clip_vision", )

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@ https://huggingface.co/Kijai/WanVideo_comfy/tree/main
 
 Text encoders to `ComfyUI/models/text_encoders`
 
+Clip vision to `ComfyUI/models/clip_vision`
+
 Transformer to `ComfyUI/models/diffusion_models`
 
 Vae to `ComfyUI/models/vae`


### PR DESCRIPTION
I first brought this topic up in #177 and part of your response was:

> it's true now it'd make more sense in the clip_vision folder, but I didn't want to change it as many people already had things setup.

Having now spent some weeks using it I can say that I'm somewhat annoyed in having to move my clip vision models around based on which nodes I'm using - as these models are usually expected to be in the `clip_vision` folder but the `LoadWanVideoClipTextEncoder` node expects them to be in the `text_encoders` folder for legacy reasons that  you mentioned in #177.

So with this PR I propose a solution. By default we expect the models to be in the `clip_vision` folder in order to achieve greater compatability with the larger ComfyUI community. However under the hood we will also still support loading the models from the `text_encoders` folder so that the people who have already set up their workflows won't experience any disruptions. Things will keep working for them.