### PR TITLE
refactor(decode): Replace min-max scaling with standard [-1, 1] conversion

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -3825,8 +3825,10 @@ class WanVideoDecode:
             images = vae.decode(latents, device=device, end_=(end_image is not None), tiled=enable_vae_tiling, tile_size=(tile_x//8, tile_y//8), tile_stride=(tile_stride_x//8, tile_stride_y//8))[0]
             vae.model.clear_cache()
 
-        images = (images - images.min()) / (images.max() - images.min())      
-
+        #images = (images - images.min()) / (images.max() - images.min())      
+        images = torch.clamp(images, -1.0, 1.0) 
+        images = (images + 1.0) / 2.0
+        
         if is_looped:
             #images = images[:, warmup_latent_count * 4:]
             temp_latents = torch.cat([latents[:, :, -3:]] + [latents[:, :, :2]], dim=2)


### PR DESCRIPTION
This PR refines the VAE output normalization to potentially improve visual quality in some cases and make the process more robust against outliers.

The previous dynamic min-max scaling was sensitive to extreme values. For instance, a single "hot pixel" (an erroneously bright or dark pixel) could skew the normalization for the entire video frame, causing a loss of detail in highlights and shadows across the whole image.

This commit replaces this method with a standard [-1, 1] to [0, 1] conversion. This approach is not affected by outliers, ensuring a more stable and accurate dynamic range, which potentially reduces subtle visual artifacts.

The TAEHV decoding path is unaffected.