### PR TITLE
Avoid 2 copies of WAN in VRAM when applying LoRA in low_mem_mode

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -73,7 +73,10 @@ def apply_lora(model, device_to, transformer_load_device, params_to_keep=None, d
                         set_module_tensor_to_device(model.model.diffusion_model, key, device=transformer_load_device, dtype=dtype_to_use, value=state_dict[key])
                     except:
                         continue
-                model.patch_weight_to_device("{}.{}".format(name, param), device_to=device_to)
+                if low_mem_load:
+                    model.patch_weight_to_device("{}.{}".format(name, param), device_to=device_to, inplace_update=True)
+                else:
+                    model.patch_weight_to_device("{}.{}".format(name, param), device_to=device_to)
                 if low_mem_load:
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, key, device=transformer_load_device, dtype=dtype_to_use, value=model.model.diffusion_model.state_dict()[key])


### PR DESCRIPTION
Avoids creating 2 copies of WAN in VRAM when applying a LoRA by setting inplace_update=True on model.patch_weight_to_device. The potential downside is that the model has to be reloaded if you change the LoRA, but this is better than not being able to load the model at all.