### PR TITLE
Use Liger Kernels for acceleration and memory reduction

### DIFF
--- a/enhance_a_video/enhance.py
+++ b/enhance_a_video/enhance.py
@@ -42,7 +42,7 @@ def feta_score(query_image, key_image, head_dim, num_frames):
     attn_temp = attn_temp.to(torch.float32)
     
     if liger_available:
-        LigerSoftmaxFunction.apply(attn_temp)
+        attn_temp = LigerSoftmaxFunction.apply(attn_temp)
     else:
         attn_temp = attn_temp.softmax(dim=-1)
 

--- a/enhance_a_video/enhance.py
+++ b/enhance_a_video/enhance.py
@@ -6,6 +6,10 @@ try:
     from liger_kernel.ops.softmax import LigerSoftmaxFunction
 
     liger_available = True
+    
+    @torch.compiler.disable
+    def liger_softmax(attn):
+        return LigerSoftmaxFunction.apply(attn)
 except Exception as e:
     liger_available = False
 
@@ -42,7 +46,7 @@ def feta_score(query_image, key_image, head_dim, num_frames):
     attn_temp = attn_temp.to(torch.float32)
     
     if liger_available:
-        attn_temp = LigerSoftmaxFunction.apply(attn_temp)
+        attn_temp = liger_softmax(attn_tmp)
     else:
         attn_temp = attn_temp.softmax(dim=-1)
 

--- a/enhance_a_video/enhance.py
+++ b/enhance_a_video/enhance.py
@@ -46,7 +46,7 @@ def feta_score(query_image, key_image, head_dim, num_frames):
     attn_temp = attn_temp.to(torch.float32)
     
     if liger_available:
-        attn_temp = liger_softmax(attn_tmp)
+        attn_temp = liger_softmax(attn_temp)
     else:
         attn_temp = attn_temp.softmax(dim=-1)
 

--- a/multitalk/multitalk.py
+++ b/multitalk/multitalk.py
@@ -11,6 +11,10 @@ try:
     from liger_kernel.ops.softmax import LigerSoftmaxFunction
 
     liger_available = True
+    
+    @torch.compiler.disable
+    def liger_softmax(attn):
+        return LigerSoftmaxFunction.apply(attn)
 except Exception as e:
     liger_available = False
 
@@ -66,7 +70,7 @@ def calculate_x_ref_attn_map(visual_q, ref_k, ref_target_masks, mode='mean', att
         attn = attn + attn_bias
 
     if liger_available:
-        x_ref_attn_map_source = LigerSoftmaxFunction.apply(attn)
+        x_ref_attn_map_source = liger_softmax(attn)
     else:
         x_ref_attn_map_source = attn.softmax(-1) # B, H, x_seqlens, ref_seqlens
 

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -278,7 +278,7 @@ class WanLayerNorm(nn.LayerNorm):
         Args:
             x(Tensor): Shape [B, L, C]
         """
-        if liger_available:
+        if liger_available and self.elementwise_affine:
             return liger_layer_norm(x, self.weight, self.bias, self.eps)
         else:
             return super().forward(x)

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -26,7 +26,7 @@ try:
     from liger_kernel.transformers import LigerLayerNorm
 
     liger_available = True
-except Exeption as e:
+except Exception as e:
     liger_available = False
 
 from .attention import attention

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -47,9 +47,8 @@ try:
         return LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)
 
     def apply_rope_liger(xq, xk, freqs_cis):
-        freqs_cis = freqs_cis.float().to(xq.device)
-        cos, sin = freqs_cis.cos(), freqs_cis.sin()
-        # cos, sin = rearrange(cos, 'n d -> 1 1 n d'), rearrange(sin, 'n d -> 1 1 n d')
+        cos = freqs_cis[..., 0]
+        sin = freqs_cis[..., 1]
         tt_q, tt_k = liger_rotary_pos_emb(xq, xk, cos, sin)
         return tt_q, tt_k
 

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -27,15 +27,7 @@ try:
     
     @torch.compiler.disable
     def liger_rms_norm(x, weight, eps):
-        return LigerRMSNormFunction.apply(
-                x,
-                weight,
-                eps,
-                offset=0.0,
-                casting_mode="llama",
-                in_place=True,
-                row_mode=None,
-            )
+        return LigerRMSNormFunction.apply(x, weight, eps, 0.0, "llama", True)
     
     @torch.compiler.disable
     def liger_layer_norm(x, weight, bias, eps):

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -47,8 +47,9 @@ try:
         return LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)
 
     def apply_rope_liger(xq, xk, freqs_cis):
-        cos = freqs_cis[..., 0]
-        sin = freqs_cis[..., 1]
+        freqs_cis = freqs_cis.float().to(xq.device)
+        cos, sin = freqs_cis.cos(), freqs_cis.sin()
+        # cos, sin = rearrange(cos, 'n d -> 1 1 n d'), rearrange(sin, 'n d -> 1 1 n d')
         tt_q, tt_k = liger_rotary_pos_emb(xq, xk, cos, sin)
         return tt_q, tt_k
 

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -23,6 +23,7 @@ except:
 try:
     from liger_kernel.ops.rms_norm import LigerRMSNormFunction
     from liger_kernel.ops.layer_norm import LigerLayerNormFunction
+    from liger_kernel.ops.rope import LigerRopeFunction
     from liger_kernel.transformers import LigerLayerNorm
     
     @torch.compiler.disable
@@ -40,6 +41,16 @@ try:
         @torch.compiler.disable
         def forward(self, *args, **kwargs):
             return super().forward(*args, **kwargs)
+
+    @torch.compiler.disable
+    def liger_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+        return LigerRopeFunction.apply(q, k, cos, sin, position_ids, unsqueeze_dim)
+
+    def apply_rope_liger(xq, xk, freqs_cis):
+        cos = freqs_cis[..., 0]
+        sin = freqs_cis[..., 1]
+        tt_q, tt_k = liger_rotary_pos_emb(xq, xk, cos, sin)
+        return tt_q, tt_k
 
     liger_available = True
 except Exception as e:
@@ -734,7 +745,10 @@ class WanAttentionBlock(nn.Module):
 
         #RoPE
         if self.rope_func == "comfy":
-            q, k = apply_rope_comfy(q, k, freqs)
+            if liger_available: # TODO: add switch
+                q, k = apply_rope_liger(q, k, freqs)
+            else:
+                q, k = apply_rope_comfy(q, k, freqs)
         elif self.rope_func == "comfy_chunked":
             q, k = apply_rope_comfy_chunked(q, k, freqs)
         else:


### PR DESCRIPTION
[Liger Kernel](https://github.com/linkedin/liger-kernel) is a collection of optimized Triton kernels designed by LinkedIn.

According to the project page, it can effectively increase throughput by 20% and reduce memory usage by 60%, which is essential to process high resolution and frame count videos. Unlike mechanisms like sage attention and caches, these are lossless, meaning no quality drop. Liger Kernels are already integrated with Huggingface Transformers library and can be activated with a simple keyword argument. They do not require any additional dependencies, only Torch and Triton, which come by default.

The following optimizations can be employed in Wan: RMSNorm, LayerNorm, Softmax and Rotary Positional embed. (the full list is on the project page)

---

Implementation progress:

- [x] LigerRMSNorm, LigerLayerNorm
- [x] Liger Softmax
- [ ] Liger RoPE
- [ ] Benchmarking