### PR TITLE
Fix animated latent preview compatibility

### DIFF
--- a/latent_preview.py
+++ b/latent_preview.py
@@ -7,6 +7,7 @@ import folder_paths
 import comfy.utils
 import logging
 import os
+import struct
 
 from .taehv import TAEHV
 
@@ -154,7 +155,7 @@ class WrappedPreviewer(LatentPreviewer):
             return None
         if self.first_preview:
             self.first_preview = False
-            serv.send_sync('VHS_latentpreview', {'length':num_images, 'rate': self.rate})
+            serv.send_sync('VHS_latentpreview', {'length':num_images, 'rate': self.rate, 'id': serv.last_node_id})
             self.last_time = new_time + 1/self.rate
         if self.c_index + num_previews > num_images:
             x0 = x0.roll(-self.c_index, 0)[:num_previews]
@@ -186,6 +187,7 @@ class WrappedPreviewer(LatentPreviewer):
             message = io.BytesIO()
             message.write((1).to_bytes(length=4, byteorder='big')*2)
             message.write(ind.to_bytes(length=4, byteorder='big'))
+            message.write(struct.pack('16p', serv.last_node_id.encode('ascii')))
             i.save(message, format="JPEG", quality=95, compress_level=1)
             #NOTE: send sync already uses call_soon_threadsafe
             serv.send_sync(server.BinaryEventTypes.PREVIEW_IMAGE,


### PR DESCRIPTION
Recent frontend changes have required that VHS to modify the way animated latent previews are transmitted. See Kosinkadink/ComfyUI-VideoHelperSuite#516

While these tweaks will work for both new and old frontend versions, they also need to be mirrored here. If needed, I can also open PRs for other wrappers you've made.

See also Kosinkadink/ComfyUI-VideoHelperSuite#520