### PR TITLE
Reduce tdqm spam

### DIFF
--- a/nodes_model_loading.py
+++ b/nodes_model_loading.py
@@ -1041,6 +1041,7 @@ class WanVideoModelLoader:
                 log.info("Using accelerate to load and assign model weights to device...")
                 param_count = sum(1 for _ in transformer.named_parameters())
                 pbar = ProgressBar(param_count)
+                cnt = 0
                 for name, param in tqdm(transformer.named_parameters(), 
                         desc=f"Loading transformer parameters to {transformer_load_device}", 
                         total=param_count,
@@ -1052,10 +1053,13 @@ class WanVideoModelLoader:
                     if "patch_embedding" in name:
                         dtype_to_use = torch.float32
                     set_module_tensor_to_device(transformer, name, device=transformer_load_device, dtype=dtype_to_use, value=sd[name])
-                    pbar.update(1)
+                    cnt += 1
+                    if cnt % 100 == 0:
+                        pbar.update(100)
 
                 #for name, param in transformer.named_parameters():
                 #    print(name, param.dtype, param.device, param.shape)
+                pbar.update_absolute(param_count)
 
         comfy_model.diffusion_model = transformer
         comfy_model.load_device = transformer_load_device
@@ -1134,6 +1138,7 @@ class WanVideoModelLoader:
         
             patcher.model.diffusion_model = _replace_with_gguf_linear(patcher.model.diffusion_model, base_dtype, sd, patches=patcher.patches)
             pbar = ProgressBar(param_count)
+            cnt = 0
             for name, param in tqdm(patcher.model.diffusion_model.named_parameters(), 
                     desc=f"Loading transformer parameters to {transformer_load_device}", 
                     total=param_count,
@@ -1146,10 +1151,14 @@ class WanVideoModelLoader:
                 else:
                     dtype_to_use = base_dtype
                 set_module_tensor_to_device(patcher.model.diffusion_model, name, device=transformer_load_device, dtype=dtype_to_use, value=sd[name])
-                pbar.update(1)
+                cnt += 1
+                if cnt % 100 == 0:
+                    pbar.update(100)
+
             #for name, param in transformer.named_parameters():
             #    print(name, param.dtype, param.device, param.shape)
             #patcher.load(device, full_load=True)
+            pbar.update_absolute(param_count)
 
         patcher.model.is_patched = True
 


### PR DESCRIPTION
During the model load the tdqm progress bar spams a lot of messages over websockets. It might not be noticeable if ComfyUI is running locally but it's very noticeable over the internet or even wi-fi (on the phone). Current behavior: 836 it/s (1.5s for the entire process of 1303 steps). Proposed change: 32032 it/s (0.04s for the same process), almost 40 times faster. While 1.5 seconds are negligible (when the model is fully cached in RAM), every update sends a message over the websocket, and it takes around 20 seconds to consume on my phone. There's no reason to send this many updates so instead I propose to send every 100th which would result in just 13 messages. Alternatively, this progress bar can be removed altogether, I suppose on an SSD/NVMe it should take only a few seconds anyway but maybe it's just me.