### PR TITLE
Propagate errors to frontend

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2335,7 +2335,7 @@ class WanVideoSampler:
                     if force_offload:
                         if model["manual_offloading"]:
                             offload_transformer(transformer)
-                    raise mm.InterruptProcessingException()
+                    raise e
 
                 #https://github.com/WeichenFan/CFG-Zero-star/
                 if use_cfg_zero_star:


### PR DESCRIPTION
The current behavior is raising a processing interrupt exception. This is suboptimal because [the actual reason of the error is swallowed](https://github.com/comfyanonymous/ComfyUI/blob/3dfefc88d00bde744b729b073058a57e149cddc1/execution.py#L626). The real reason is only printed in the console but not in the UI. In particular, my frontend [CozyUI](https://github.com/SD-inst/cozyui) relies on proper error messages that are delivered via `execution_error`, not `execution_interrupted`. The latter, as I understand it, should only be sent in response to the user cancelling a task, never when an internal error occurs. When an OOM happens (the most common error) I expect it to be reported via `execution_error`, but instead I get `execution_interrupted` and the UI doesn't expect it because the user never cancelled the task explicitly.

While I understand it's not a critical issue for pure ComfyUI workflows and it only breaks my own code (and expectations), it would be nice to follow the common patterns.