### PR TITLE
Fix res_multistep.step to set sigma_next correctly when ending early

### DIFF
--- a/wanvideo/schedulers/flowmatch_res_multistep.py
+++ b/wanvideo/schedulers/flowmatch_res_multistep.py
@@ -51,7 +51,7 @@ class FlowMatchSchedulerResMultistep():
         
         sigma = self.sigmas[timestep_id].reshape(-1, 1, 1, 1)
         sigma_prev = self.sigmas[timestep_id - 1].reshape(-1, 1, 1, 1) if timestep_id > 0 else sigma
-        if (timestep_id + 1 >= len(self.timesteps)).any():
+        if (timestep_id + 1 >= len(self.sigmas)).any():
             sigma_next = torch.tensor(0)
         else:
             sigma_next = self.sigmas[timestep_id + 1].reshape(-1, 1, 1, 1)


### PR DESCRIPTION
Current code determines that `sigma_next=0` when on the end step. But since one may want to set end_step < total_steps (e.g., WAN MOE models), the next sigma may not be 0. 

Since current implementation ensures that `self.sigmas` includes sigma_(n+1) when non-zero, but does not when it is zero, I believe simply replacing len(self.timesteps) with len(self.sigmas) solves this issue.