### PR TITLE
correctly extract lora name

### DIFF
--- a/nodes_model_loading.py
+++ b/nodes_model_loading.py
@@ -425,7 +425,7 @@ class WanVideoLoraSelect:
         lora = {
             "path": lora_path,
             "strength": strength,
-            "name": lora.split(".")[0],
+            "name": os.path.splitext(lora)[0],
             "blocks": blocks.get("selected_blocks", {}),
             "layer_filter": blocks.get("layer_filter", ""),
             "low_mem_load": low_mem_load,
@@ -490,7 +490,7 @@ class WanVideoLoraSelectMulti:
             loras_list.append({
                 "path": folder_paths.get_full_path("loras", lora_name),
                 "strength": s,
-                "name": lora_name.split(".")[0],
+                "name": os.path.splitext(lora_name)[0],
                 "blocks": blocks.get("selected_blocks", {}),
                 "layer_filter": blocks.get("layer_filter", ""),
                 "low_mem_load": low_mem_load,


### PR DESCRIPTION
Hi, this PR fixes a minor issue with LoRa name extraction in the LoRa selection nodes that has been bugging me. The current code will split on the first `.` which can cut off part of the LoRa name if the LoRa name contains multiple periods. This can make debugging more difficult when submitting prompts via the ComfyUI API, for example.