### PR TITLE
Fix: Correct display name typo for TeaCache node

### DIFF
--- a/cache_methods/nodes_cache.py
+++ b/cache_methods/nodes_cache.py
@@ -134,7 +134,7 @@ NODE_CLASS_MAPPINGS = {
     "WanVideoEasyCache": WanVideoEasyCache,
     }
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "WanVideoTeaCache": "WaWanVideo TeaCache",
+    "WanVideoTeaCache": "WanVideo TeaCache",
     "WanVideoMagCache": "WanVideo MagCache",
     "WanVideoEasyCache": "WanVideo EasyCache"
     }


### PR DESCRIPTION
This PR fixes a small typo in the display name for the TeaCache node