### PR TITLE
Fix frame alignment error in WanVideoAnimateEmbeds

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1204,6 +1204,13 @@ class WanVideoAnimateEmbeds:
                 ref_mask[:, :num_refs] = 1
             ref_mask_mask_repeated = torch.repeat_interleave(ref_mask[:, 0:1], repeats=4, dim=1) # T, C, H, W
             ref_mask = torch.cat([ref_mask_mask_repeated, ref_mask[:, 1:]], dim=1)
+            
+            # Ensure frame count is divisible by 4 before reshaping
+            frames_to_use = (ref_mask.shape[1] // 4) * 4
+            if frames_to_use < ref_mask.shape[1]:
+                log.info(f"WanAnimate: Trimming ref_mask from {ref_mask.shape[1]} to {frames_to_use} frames to ensure divisibility by 4")
+                ref_mask = ref_mask[:, :frames_to_use]
+            
             ref_mask = ref_mask.view(1, ref_mask.shape[1] // 4, 4, lat_h, lat_w) # 1, T, C, H, W
             ref_mask = ref_mask.movedim(1, 2)[0]# C, T, H, W
 


### PR DESCRIPTION
Fixed a tensor reshaping error in WanVideoAnimateEmbeds that occurred when processing videos w/ frame counts not divisible by 4. The fix trims excess frames (max 3) to ensure proper alignment w/ the 4-frame latent processing pipeline.

## Issue
WanVideoAnimateEmbeds fails w/ `RuntimeError: shape '[1, X, 4, H, W]' is invalid for input of size Y` when processing videos where the frame count is not divisible by 4 b/c some videos can have arbitrary frame counts (e.g., 77, 83, 165 frames).

## Fix
Added frame alignment check before reshaping:
- Calculates the largest frame count divisible by 4
- Trims excess frames w/ minimal data loss (≤3 frames regardless of video length)
- Logs the operation for transparency
- Ensures tensor reshaping occurs & prevents crashes for videos with non-aligned frame counts
- Maintains backward compatibility for properly aligned videos