### PR TITLE
Fix WanAnimate first chunk ignoring bg_images and ref_images

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -2632,7 +2632,7 @@ class WanVideoSampler:
                             noise = torch.randn(16, latent_window_size + 1, lat_h, lat_w, dtype=torch.float32, device=torch.device("cpu"), generator=seed_g).to(device)
                             seq_len = math.ceil((noise.shape[2] * noise.shape[3]) / 4 * noise.shape[1])
 
-                            if current_ref_images is not None:
+                            if current_ref_images is not None or bg_images is not None or ref_latent is not None:
                                 if offload:
                                     offload_transformer(transformer)
                                     offloaded = True


### PR DESCRIPTION
Noticed that on the first iteration, current_ref_images is None (no previous frames yet), causing the entire conditioning block to be skipped and replaced with zeros, even when bg_images and ref_images are provided.

I changed condition from checking only current_ref_images to also checking bg_images and ref_latent, ensuring proper processing on the first chunk.
