### PR TITLE
Fix Uni3C + Context Options compatibility (Issue #1491)

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -1981,7 +1981,7 @@ class WanVideoSampler:
                                 mtv_motion_tokens=partial_mtv_motion_tokens, s2v_audio_input=partial_s2v_audio_input, s2v_motion_frames=[1, 0], s2v_pose=partial_s2v_pose,
                                 humo_image_cond=humo_image_cond, humo_image_cond_neg=humo_image_cond_neg, humo_audio=humo_audio, humo_audio_neg=humo_audio_neg,
                                 wananim_face_pixels=partial_wananim_face_pixels, wananim_pose_latents=partial_wananim_pose_latents, multitalk_audio_embeds=multitalk_audio_embeds,
-                                flashvsr_LQ_latent=partial_flashvsr_LQ_latent)
+                                uni3c_data=uni3c_data, flashvsr_LQ_latent=partial_flashvsr_LQ_latent)
 
                             if cache_args is not None:
                                 self.window_tracker.cache_states[window_id] = new_teacache


### PR DESCRIPTION
## Problem
When using Uni3C with Context Options, the camera effect stops working. This regression was introduced in recent updates where the `uni3c_data` parameter was not being passed to `predict_with_cfg()` in the context windowing loop.

## Root Cause
In `nodes_sampler.py` line 1982-1991, the context options loop calls `predict_with_cfg()` but was missing the `uni3c_data` parameter, while other sampling modes (multitalk, wananimate) correctly pass this parameter.

## Solution
Added `uni3c_data=uni3c_data` parameter to the `predict_with_cfg()` call in the context windowing loop (line 1991), making it consistent with other sampling modes.

## Testing
- ✅ Tested Uni3C + Context Options - camera effect works correctly
- ✅ Tested Uni3C without Context Options - no regression
- ✅ Long video generation now works properly with Context Options
- ✅ Memory usage is as expected with context windowing

## Changes
- `nodes_sampler.py`: Added `uni3c_data=uni3c_data` parameter at line 1991
- `PATCH_REVIEW.md`: Added detailed technical analysis and documentation

Fixes #1491

## Additional Context
The code already has automatic slicing logic for `uni3c_data` based on `context_window` (lines 1272-1278), so no additional partial processing is needed. This fix simply ensures the data flows through the context windowing loop correctly.