### PR TITLE
Fix dtype mismatch in ref_conv forward pass

### DIFF
--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -2329,7 +2329,7 @@ class WanModel(torch.nn.Module):
                 block.self_attn.mask_map = MaskMap(video_token_num=seq_len, num_frame=F+1)
 
         if self.ref_conv is not None and fun_ref is not None:
-            fun_ref = self.ref_conv(fun_ref).flatten(2).transpose(1, 2)
+            fun_ref = self.ref_conv(fun_ref.to(self.ref_conv.weight.dtype)).flatten(2).transpose(1, 2)
             grid_sizes = torch.stack([torch.tensor([u[0] + 1, u[1], u[2]]) for u in grid_sizes]).to(grid_sizes.device)
             seq_len += fun_ref.size(1)
             F += 1


### PR DESCRIPTION
## Issue
Fixes a `RuntimeError` that occurs when using Fun-Control reference images:
```
RuntimeError: Input type (float) and bias type (c10::Half) should be the same
```

## Root Cause
- Commit 1ba1a16 ("cleanup and use fp32 text/time embed if available") changed the dtype handling strategy
- The main latent `x` is now converted to `base_dtype` instead of converting embeddings to match `x.dtype`
- This caused `fun_ref` input to be in a different dtype than the `ref_conv` layer's weights and bias
- Line 2324 already handles this correctly for `attn_cond` by converting to `self.attn_conv_in.weight.dtype`

## Solution
Convert `fun_ref` to match `self.ref_conv.weight.dtype` before passing through the convolution layer, following the same pattern used for `attn_cond` on line 2324.

## Changes
- **File**: `wanvideo/modules/model.py`
- **Line**: 2332
- **Change**: Added `.to(self.ref_conv.weight.dtype)` to ensure dtype compatibility

## Testing
Tested with Fun-Control reference images and confirmed the error is resolved.