### PR TITLE
fix: initialize image_cond_mask to prevent UnboundLocalError in I2V

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -225,6 +225,7 @@ class WanVideoSampler:
         #I2V
         story_mem_latents = image_embeds.get("story_mem_latents", None)
         image_cond = image_embeds.get("image_embeds", None)
+        image_cond_mask = None  # ✅ 关键：无论是否使用 mask，都先初始化
         if image_cond is not None:
             if transformer.in_dim == 16:
                 raise ValueError("T2V (text to video) model detected, encoded images only work with I2V (Image to video) models")


### PR DESCRIPTION
## Problem
When running I2V with Fun 2.1 models (transformer.in_dim in [48, 32]), the mask assignment branch is skipped.
However, `image_cond_mask` is referenced later, causing:

UnboundLocalError: cannot access local variable 'image_cond_mask' where it is not associated with a value

## Fix
Initialize `image_cond_mask = None` before conditional assignment so it is always defined.

This is a minimal change and does not alter behavior when a mask is provided.
