### PR TITLE
       Fix: Fix torch.arange bounds error in context window processing

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -1986,13 +1986,13 @@ class WanVideoSampler:
                             partial_wananim_face_pixels = partial_wananim_pose_latents = None
                             if wananim_face_pixels is not None and partial_wananim_face_pixels is None:
                                 start = c[0] * 4
-                                end = c[-1] * 4
+                                end = c[-1] * 4 + 1
                                 center_indices = torch.arange(start, end, 1)
                                 center_indices = torch.clamp(center_indices, min=0, max=wananim_face_pixels.shape[2] - 1)
                                 partial_wananim_face_pixels = wananim_face_pixels[:, :, center_indices].to(device, dtype)
                             if wananim_pose_latents is not None:
                                 start = c[0]
-                                end = c[-1]
+                                end = c[-1] + 1
                                 center_indices = torch.arange(start, end, 1)
                                 center_indices = torch.clamp(center_indices, min=0, max=wananim_pose_latents.shape[2] - 1)
                                 partial_wananim_pose_latents = wananim_pose_latents[:, :, center_indices][:, :, :context_frames-1].to(device, dtype)


### PR DESCRIPTION
## Problem

When using `WanVideoContextOptions` with pose latents (`wananim_pose_latents` or `wananim_face_pixels`), the code throws a runtime error:

```
RuntimeError: upper bound and lower bound inconsistent with step sign
```


This occurs at lines 2201 and 2207 in `nodes_sampler.py` when `torch.arange(start, end, 1)` is called with `start >= end`. This can happen when:
- The context window `c` contains only a single element (e.g., `c = [42]`)
- The context window has been processed in a way that results in `c[0] == c[-1]`

## Root Cause

The code calculates the end index as:
- `end = c[-1] * 4` for `wananim_face_pixels` (line 2201)
- `end = c[-1]` for `wananim_pose_latents` (line 2207)

When `c` has only one element, `c[0] == c[-1]`, making `start == end`, which causes `torch.arange(start, end, 1)` to fail because it cannot create a range where the start equals or exceeds the end.

## Solution

Changed the end index calculation to include the last frame:
- `end = c[-1] * 4 + 1` for `wananim_face_pixels` (line 2201)
- `end = c[-1] + 1` for `wananim_pose_latents` (line 2207)

This ensures that `torch.arange(start, end, 1)` always creates a valid range that includes the last frame. The existing `torch.clamp()` call ensures no out-of-bounds access, making this change safe.

## Changes Made

- **Line 2201**: Changed `end = c[-1] * 4` to `end = c[-1] * 4 + 1`
- **Line 2207**: Changed `end = c[-1]` to `end = c[-1] + 1`

## Testing

- ✅ Tested with 250-frame video processing using `WanVideoContextOptions`
- ✅ Verified no regression with existing workflows
- ✅ Confirmed `torch.clamp()` properly handles edge cases

## Related

Fixes the issue where context window processing fails when processing pose-based animations with `WanVideoContextOptions`.