### PR TITLE
Fix MultiTalk + SCAIL pose compatibility, expose audio_scale on SilentEmbeds

### DIFF
--- a/multitalk/nodes.py
+++ b/multitalk/nodes.py
@@ -352,7 +352,7 @@ class MultiTalkSilentEmbeds:
     def INPUT_TYPES(s):
         return {"required": {
             "num_frames": ("INT", {"default": 81, "min": 1, "max": 10000, "step": 1, "tooltip": "The total frame count to generate."}),
-            "audio_scale": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.05, "tooltip": "Strength of the silence conditioning. Higher = stronger mouth closing effect."}),
+            "audio_scale": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 100.0, "step": 0.01, "tooltip": "Strength of the audio conditioning"}),
         },
         }
 

--- a/multitalk/nodes.py
+++ b/multitalk/nodes.py
@@ -352,6 +352,7 @@ class MultiTalkSilentEmbeds:
     def INPUT_TYPES(s):
         return {"required": {
             "num_frames": ("INT", {"default": 81, "min": 1, "max": 10000, "step": 1, "tooltip": "The total frame count to generate."}),
+            "audio_scale": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.05, "tooltip": "Strength of the silence conditioning. Higher = stronger mouth closing effect."}),
         },
         }
 
@@ -360,17 +361,17 @@ class MultiTalkSilentEmbeds:
     FUNCTION = "process"
     CATEGORY = "WanVideoWrapper"
 
-    def process(self, num_frames):
+    def process(self, num_frames, audio_scale):
         silence_path = os.path.join(script_directory, "encoded_silence.safetensors")
         encoded_silence = load_torch_file(silence_path)["audio_emb"]
-       
+
         target_frames = num_frames
         repeats = (target_frames + encoded_silence.shape[0] - 1) // encoded_silence.shape[0]
         repeated = encoded_silence.repeat(repeats, 1, 1)
         repeated = repeated[:target_frames]
         multitalk_embeds = {
             "audio_features": repeated,
-            "audio_scale": 1.0,
+            "audio_scale": audio_scale,
             "audio_cfg_scale": 1.0,
             "ref_target_masks": None
         }

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -1343,8 +1343,25 @@ class WanAttentionBlock(nn.Module):
                         if audio_output_cond is not None:
                             x_audio = torch.cat([audio_output_cond, x_audio], dim=1).contiguous()
                     else:
-                        x_audio = self.audio_cross_attn(self.norm_x(x.to(self.norm_x.weight.dtype)).to(input_dtype), encoder_hidden_states=multitalk_audio_embedding,
-                                                    shape=grid_sizes[0], x_ref_attn_map=x_ref_attn_map, human_num=human_num)
+                        x_normed = self.norm_x(x.to(self.norm_x.weight.dtype)).to(input_dtype)
+                        grid_tokens = grid_sizes[0].prod().item()
+                        audio_shape = grid_sizes[0]
+                        if x_normed.shape[1] > grid_tokens:
+                            N_h, N_w = grid_sizes[0][1].item(), grid_sizes[0][2].item()
+                            S = N_h * N_w
+                            audio_N_t = multitalk_audio_embedding.shape[0]
+                            audio_tokens = audio_N_t * S
+                            x_for_audio = x_normed[:, :audio_tokens]
+                            audio_shape = torch.tensor([audio_N_t, N_h, N_w], device=grid_sizes.device, dtype=grid_sizes.dtype)
+                        else:
+                            x_for_audio = x_normed
+                            audio_tokens = grid_tokens
+                        x_audio = self.audio_cross_attn(x_for_audio, encoder_hidden_states=multitalk_audio_embedding,
+                                                    shape=audio_shape, x_ref_attn_map=x_ref_attn_map, human_num=human_num)
+                        if x_normed.shape[1] > grid_tokens:
+                            x_audio_padded = torch.zeros(x.shape, dtype=x_audio.dtype, device=x_audio.device)
+                            x_audio_padded[:, :audio_tokens] = x_audio
+                            x_audio = x_audio_padded
                     x.add_(x_audio, alpha=audio_scale)
                     del x_audio
 

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -1344,21 +1344,19 @@ class WanAttentionBlock(nn.Module):
                             x_audio = torch.cat([audio_output_cond, x_audio], dim=1).contiguous()
                     else:
                         x_normed = self.norm_x(x.to(self.norm_x.weight.dtype)).to(input_dtype)
-                        grid_tokens = grid_sizes[0].prod().item()
-                        audio_shape = grid_sizes[0]
-                        if x_normed.shape[1] > grid_tokens:
-                            N_h, N_w = grid_sizes[0][1].item(), grid_sizes[0][2].item()
-                            S = N_h * N_w
-                            audio_N_t = multitalk_audio_embedding.shape[0]
-                            audio_tokens = audio_N_t * S
+                        N_h, N_w = grid_sizes[0][1].item(), grid_sizes[0][2].item()
+                        S = N_h * N_w
+                        audio_N_t = multitalk_audio_embedding.shape[0]
+                        audio_tokens = audio_N_t * S
+                        if grid_sizes[0][0].item() != audio_N_t or x_normed.shape[1] != audio_tokens:
                             x_for_audio = x_normed[:, :audio_tokens]
                             audio_shape = torch.tensor([audio_N_t, N_h, N_w], device=grid_sizes.device, dtype=grid_sizes.dtype)
                         else:
                             x_for_audio = x_normed
-                            audio_tokens = grid_tokens
+                            audio_shape = grid_sizes[0]
                         x_audio = self.audio_cross_attn(x_for_audio, encoder_hidden_states=multitalk_audio_embedding,
                                                     shape=audio_shape, x_ref_attn_map=x_ref_attn_map, human_num=human_num)
-                        if x_normed.shape[1] > grid_tokens:
+                        if x_normed.shape[1] > audio_tokens:
                             x_audio_padded = torch.zeros(x.shape, dtype=x_audio.dtype, device=x_audio.device)
                             x_audio_padded[:, :audio_tokens] = x_audio
                             x_audio = x_audio_padded


### PR DESCRIPTION
## Summary

- **Fix audio_cross_attn shape mismatch when used with SCAIL pose conditioning**: SCAIL's ref_latent modifies `grid_sizes` temporal dimension and may append extra tokens to `x`, causing `audio_cross_attn` to fail with shape errors. The fix detects when audio temporal frames differ from `grid_sizes` or `x` token count, and corrects the shape/slice before calling `audio_cross_attn`.
- **Expose `audio_scale` parameter on `MultiTalkSilentEmbeds`**: Previously hardcoded to 1.0. Users can now adjust silence conditioning strength (e.g. 0.3-0.5 for less color shift while still suppressing unwanted mouth movements). Parameter range/step matches `MultiTalkWav2VecEmbeds` for consistency.

## Backward compatibility

The model.py fix only activates when `grid_sizes[0][0] != audio_N_t` or `x_normed.shape[1] != audio_tokens`. In all existing workflows (MultiTalk, InfiniteTalk, LongCat, etc.) these values match, so the else branch is taken — identical to the original code path. Zero impact on non-SCAIL workflows.

The `audio_scale` parameter defaults to 1.0, preserving existing behavior.

## Test plan

- [x] SCAIL pose + MultiTalk SilentEmbeds: generates successfully, no shape errors
- [x] Tested with various audio_scale values (0.3, 0.5, 1.0)
- [x] Non-SCAIL MultiTalk workflows unaffected
