### PR TITLE
fix: replace 47 bare excepts with except Exception

### DIFF
--- a/MTV/nodes.py
+++ b/MTV/nodes.py
@@ -31,7 +31,7 @@ def check_jit_script_function():
                     f"  Qualified name: {qualname}\n"
                     f"  Defined in: {code_file}:{code_line}\n"
                     f"This may cause issues with the NLF model.")
-        except:
+        except Exception:
             log.warning("--------------------------------")
             log.warning(f"torch.jit.script function is: {torch.jit.script.__name__} from module {module}, "
                     f"this has been modified by another custom node. This may cause issues with the NLF model.")

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ try:
         for dir_path in duplicate_dirs:
             warning_msg += f"  - {color_text(dir_path, 'yellow')}\n"
         log.warning(color_text(warning_msg + "Please remove duplicates to avoid possible conflicts.", "red"))
-except:
+except Exception:
     pass
 
 from .utils import log

--- a/fantasytalking/nodes.py
+++ b/fantasytalking/nodes.py
@@ -167,7 +167,7 @@ class FantasyTalkingWav2VecEmbeds:
 
         try:
             audio_segment = audio_input[start_sample:end_sample]
-        except:
+        except Exception:
             audio_segment = audio_input
 
         print("audio_segment.shape", audio_segment.shape)

--- a/latent_preview.py
+++ b/latent_preview.py
@@ -85,7 +85,7 @@ def get_previewer(device, latent_format):
                 taesd = TAEHV(comfy.utils.load_torch_file(taehv_path)).to(device)
                 previewer = TAESDPreviewerImpl(taesd)
                 previewer = WrappedPreviewer(previewer, rate=16)
-            except:
+            except Exception:
                 log.info("Could not find TAEW model file 'taew2_1.safetensors' from models/vae_approx. You can download it from https://huggingface.co/Kijai/WanVideo_comfy/blob/main/taew2_1.safetensors")
                 log.info("Using Latent2RGB previewer instead.")
                 method = LatentPreviewMethod.Latent2RGB

--- a/multitalk/multitalk_loop.py
+++ b/multitalk/multitalk_loop.py
@@ -113,7 +113,7 @@ def multitalk_loop(self, **kwargs):
     try:
         silence_path = os.path.join(script_directory, "encoded_silence.safetensors")
         encoded_silence = load_torch_file(silence_path)["audio_emb"].to(dtype)
-    except:
+    except Exception:
             log.warning("No encoded silence file found, padding with end of audio embedding instead.")
 
     total_frames = len(audio_embedding[0])
@@ -564,6 +564,6 @@ def multitalk_loop(self, **kwargs):
     try:
         print_memory(device)
         torch.cuda.reset_peak_memory_stats(device)
-    except:
+    except Exception:
         pass
     return {"video": gen_video_samples.permute(1, 2, 3, 0), "output_path": output_path},

--- a/multitalk/nodes.py
+++ b/multitalk/nodes.py
@@ -128,7 +128,7 @@ class MultiTalkModelLoader:
 def loudness_norm(audio_array, sr=16000, lufs=-23):
     try:
         import pyloudnorm
-    except:
+    except Exception:
         raise ImportError("pyloudnorm package is not installed")
     meter = pyloudnorm.Meter(sr)
     loudness = meter.integrated_loudness(audio_array)

--- a/nodes.py
+++ b/nodes.py
@@ -327,7 +327,7 @@ class WanVideoTextEncode:
             try:
                 log.info(f"Moving video model to {offload_device}")
                 model_to_offload.model.to(offload_device)
-            except:
+            except Exception:
                 pass
 
         encoder = t5["model"]
@@ -502,7 +502,7 @@ class WanVideoTextEncodeSingle:
                     log.info(f"Moving video model to {offload_device}")
                     model_to_offload.model.to(offload_device)
                     mm.soft_empty_cache()
-            except:
+            except Exception:
                 pass
 
             encoder = t5["model"]

--- a/nodes_model_loading.py
+++ b/nodes_model_loading.py
@@ -23,7 +23,7 @@ from comfy.sd import load_lora_for_models
 try:
     from .gguf.gguf import _replace_with_gguf_linear, GGUFParameter
     from gguf import GGMLQuantizationType
-except:
+except Exception:
     pass
 
 script_directory = os.path.dirname(os.path.abspath(__file__))
@@ -33,7 +33,7 @@ offload_device = mm.unet_offload_device()
 
 try:
     from server import PromptServer
-except:
+except Exception:
     PromptServer = None
 
 attention_modes = ["sdpa", "flash_attn_2", "flash_attn_3", "sageattn", "sageattn_3", "radial_sage_attention", "sageattn_compiled",
@@ -414,7 +414,7 @@ class WanVideoLoraSelect:
 
         try:
             lora_path = folder_paths.get_full_path_or_raise("loras", lora)
-        except:
+        except Exception:
             lora_path = lora
 
         # Load metadata from the safetensors file
@@ -1151,7 +1151,7 @@ class WanVideoModelLoader:
             try:
                 if hasattr(torch.backends.cuda.matmul, "allow_fp16_accumulation"):
                     torch.backends.cuda.matmul.allow_fp16_accumulation = False
-            except:
+            except Exception:
                 pass
 
 

--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -1730,7 +1730,7 @@ class WanVideoSampler:
         gc.collect()
         try:
             torch.cuda.reset_peak_memory_stats(device)
-        except:
+        except Exception:
             pass
 
         # Main sampling loop with FreeInit iterations
@@ -2182,7 +2182,7 @@ class WanVideoSampler:
                         try:
                             print_memory(device)
                             torch.cuda.reset_peak_memory_stats(device)
-                        except:
+                        except Exception:
                             pass
                         return {"video": gen_video_samples},
                     # region wananimate loop
@@ -2483,7 +2483,7 @@ class WanVideoSampler:
                         try:
                             print_memory(device)
                             torch.cuda.reset_peak_memory_stats(device)
-                        except:
+                        except Exception:
                             pass
                         return {"video": gen_video_samples.permute(1, 2, 3, 0), "output_path": output_path},
 
@@ -2627,7 +2627,7 @@ class WanVideoSampler:
         try:
             print_memory(device)
             torch.cuda.reset_peak_memory_stats(device)
-        except:
+        except Exception:
             pass
         return ({
             "samples": latent.unsqueeze(0).cpu(),
@@ -2771,7 +2771,7 @@ class WanVideoScheduler:
             import io
             import base64
             import matplotlib.pyplot as plt
-        except:
+        except Exception:
             PromptServer = None
         if unique_id and PromptServer is not None:
             try:

--- a/nodes_utility.py
+++ b/nodes_utility.py
@@ -9,7 +9,7 @@ from einops import rearrange
 
 try:
     from server import PromptServer
-except:
+except Exception:
     PromptServer = None
 
 VAE_STRIDE = (4, 8, 8)
@@ -256,7 +256,7 @@ class CreateCFGScheduleFloatList:
                     f"{cfg_list}",
                     unique_id
                 )
-            except:
+            except Exception:
                 pass
 
         return (cfg_list,)
@@ -319,7 +319,7 @@ class CreateScheduleFloatList:
                     f"{cfg_list}",
                     unique_id
                 )
-            except:
+            except Exception:
                 pass
 
         return (cfg_list,)
@@ -454,7 +454,7 @@ class NormalizeAudioLoudness:
     def loudness_norm(self, audio_array, sr=16000, lufs=-23):
         try:
             import pyloudnorm
-        except:
+        except Exception:
             raise ImportError("pyloudnorm package is not installed")
         meter = pyloudnorm.Meter(sr)
         loudness = meter.integrated_loudness(audio_array)

--- a/skyreels/nodes.py
+++ b/skyreels/nodes.py
@@ -548,7 +548,7 @@ class WanVideoDiffusionForcingSampler:
         gc.collect()
         try:
             torch.cuda.reset_peak_memory_stats(device)
-        except:
+        except Exception:
             pass
 
         #region main loop start
@@ -615,7 +615,7 @@ class WanVideoDiffusionForcingSampler:
         try:
             print_memory(device)
             torch.cuda.reset_peak_memory_stats(device)
-        except:
+        except Exception:
             pass
 
         return ({

--- a/unianimate/nodes.py
+++ b/unianimate/nodes.py
@@ -200,7 +200,7 @@ def pose_extract(pose_images, ref_image, dwpose_model, height, width, score_thre
     if ref_image is not None:
         try:
             pose_ref = dwpose_model(ref_image.squeeze(0), score_threshold=score_threshold)
-        except:
+        except Exception:
             raise ValueError("No pose detected in reference image")
     prev_pose = None
     for img in tqdm(pose_images, desc="Pose Extraction", unit="image", total=len(pose_images)):
@@ -208,7 +208,7 @@ def pose_extract(pose_images, ref_image, dwpose_model, height, width, score_thre
             pose = dwpose_model(img, score_threshold=score_threshold)
             if handle_not_detected == "repeat":
                 prev_pose = pose
-        except:
+        except Exception:
             if prev_pose is not None:
                 pose = prev_pose
             else:
@@ -675,7 +675,7 @@ def pose_extract(pose_images, ref_image, dwpose_model, height, width, score_thre
                                                     draw_body=draw_body, draw_hands=draw_hands, hand_keypoint_size=hand_keypoint_size,
                                                     draw_feet=draw_feet, body_keypoint_size=body_keypoint_size, draw_head=draw_head)
         result = torch.from_numpy(dwpose_woface)
-        #except:
+        #except Exception:
         #    result = torch.zeros((height, width, 3), dtype=torch.uint8)
         dwpose_woface_list.append(result)
     dwpose_woface_tensor = torch.stack(dwpose_woface_list, dim=0)

--- a/utils.py
+++ b/utils.py
@@ -12,7 +12,7 @@ from comfy.lora import calculate_weight
 
 try:
     from comfy.utils import string_to_seed
-except:
+except Exception:
     from comfy.model_patcher import string_to_seed
 
 from comfy.float import stochastic_rounding
@@ -27,7 +27,7 @@ offload_device = mm.unet_offload_device()
 
 try:
     from .gguf.gguf import GGUFParameter
-except:
+except Exception:
     pass
 
 COLOR_CODES = {
@@ -309,7 +309,7 @@ def apply_lora(model, device_to, transformer_load_device, params_to_keep=None, d
                     key = f"{name.replace('diffusion_model.', '')}.{param}"
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, key, device=transformer_load_device, dtype=dtype_to_use, value=state_dict[key])
-                    except:
+                    except Exception:
                         continue
                 key = f"{name}.{param}"
                 if scale_weights is not None:
@@ -323,7 +323,7 @@ def apply_lora(model, device_to, transformer_load_device, params_to_keep=None, d
                 if low_mem_load:
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, key, device=transformer_load_device, dtype=dtype_to_use, value=model.model.diffusion_model.state_dict()[key])
-                    except:
+                    except Exception:
                         continue
             m.comfy_patched_weights = True
             cnt += 1
@@ -352,7 +352,7 @@ def apply_lora(model, device_to, transformer_load_device, params_to_keep=None, d
                         dtype_to_use = torch.float32
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, name, device=transformer_load_device, dtype=dtype_to_use, value=state_dict[name])
-                    except:
+                    except Exception:
                         continue
         return model
 

--- a/wanvideo/modules/attention.py
+++ b/wanvideo/modules/attention.py
@@ -65,16 +65,16 @@ try:
         # Return tensor with same shape as q
         return q.clone()
     sageattn_varlen_func = torch.ops.wanvideo.sageattn_varlen
-except:
+except Exception:
     sageattn_varlen_func = attention_func_error
 
 # sage3
 try:
     from sageattn3 import sageattn3_blackwell as sageattn_blackwell
-except:
+except Exception:
     try:
         from sageattn import sageattn_blackwell
-    except:
+    except Exception:
         sageattn_blackwell = attention_func_error
 
 try:
@@ -88,7 +88,7 @@ try:
     def _(qkv, attn_mask=None, dropout_p=0.0, is_causal=False, multi_factor=0.9):
         return torch.empty_like(qkv[0]).contiguous()
     sageattn_func_ultravico = torch.ops.wanvideo.sageattn_ultravico
-except:
+except Exception:
     sageattn_func_ultravico = attention_func_error
 
 

--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -10,7 +10,7 @@ from contextlib import nullcontext
 
 try:
     from ..radial_attention.attn_mask import RadialSpargeSageAttn, RadialSpargeSageAttnDense, MaskMap
-except:
+except Exception:
     pass
 
 from .attention import attention

--- a/wanvideo/radial_attention/attn_mask.py
+++ b/wanvideo/radial_attention/attn_mask.py
@@ -4,15 +4,15 @@ import torch
 try:
     from spas_sage_attn import block_sparse_sage2_attn_cuda
     sparse_attn_func = block_sparse_sage2_attn_cuda
-except:
+except Exception:
     try:
         from sparse_sageattn import sparse_sageattn
         sparse_attn_func = sparse_sageattn
-    except:
+    except Exception:
         try:
             from .sparse_sage.core import sparse_sageattn
             sparse_attn_func = sparse_sageattn
-        except:
+        except Exception:
             sparse_sageattn = None
             raise ImportError("sparse_sageattn is not available. Please install the sparse_sageattn package or check your import path.")
 

--- a/wanvideo/wan_video_vae.py
+++ b/wanvideo/wan_video_vae.py
@@ -1061,7 +1061,7 @@ class VideoVAE_(nn.Module):
             pbar = ProgressBar(iter_)
         try:
             torch.cuda.reset_peak_memory_stats(device)
-        except:
+        except Exception:
             pass
 
         for i in tqdm(range(iter_), desc="WanVAE encoding frames", disable=not pbar):
@@ -1092,7 +1092,7 @@ class VideoVAE_(nn.Module):
                 log.info(f"WanVAE encoded input:{input_shape} to {out.shape}")
                 print_memory(device, process="WanVAE encode")
                 torch.cuda.reset_peak_memory_stats(device)
-            except:
+            except Exception:
                 pass
         return mu
 
@@ -1137,7 +1137,7 @@ class VideoVAE_(nn.Module):
             pbar = ProgressBar(iter_)
         try:
             torch.cuda.reset_peak_memory_stats(device)
-        except:
+        except Exception:
             pass
         x = self.conv2(z)
         for i in tqdm(range(iter_), desc="WanVAE decoding frames", disable=not pbar):
@@ -1162,7 +1162,7 @@ class VideoVAE_(nn.Module):
                 log.info(f"WanVAE decoded input:{input_shape} to {out.shape}")
                 print_memory(device, process="WanVAE decode")
                 torch.cuda.reset_peak_memory_stats(device)
-            except:
+            except Exception:
                 pass
         return out
 
@@ -1464,7 +1464,7 @@ class VideoVAE38_(VideoVAE_):
         self.clear_cache()
         try:
             torch.cuda.reset_peak_memory_stats(device)
-        except:
+        except Exception:
             pass
         x = patchify(x, patch_size=2)
         t = x.shape[2]
@@ -1492,7 +1492,7 @@ class VideoVAE38_(VideoVAE_):
                 log.info(f"WanVAE decoded input:{input_shape} to {out.shape}")
                 print_memory(device, process="WanVAE decode")
                 torch.cuda.reset_peak_memory_stats(device)
-            except:
+            except Exception:
                 pass
         return mu
 
@@ -1502,7 +1502,7 @@ class VideoVAE38_(VideoVAE_):
         input_shape = z.shape
         try:
             torch.cuda.reset_peak_memory_stats(device)
-        except:
+        except Exception:
             pass
         z = z / self.inv_std.to(z) + self.mean.to(z)
 
@@ -1531,7 +1531,7 @@ class VideoVAE38_(VideoVAE_):
                 log.info(f"WanVAE decoded input:{input_shape} to {out.shape}")
                 print_memory(device, process="WanVAE decode")
                 torch.cuda.reset_peak_memory_stats(device)
-            except:
+            except Exception:
                 pass
         return out
 


### PR DESCRIPTION
Replace 47 bare `except:` with `except Exception:` across 17 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.