### PR TITLE
Fix missing parameter for WanModel CrossAttn attention_mode.

### DIFF
--- a/wanvideo/modules/model.py
+++ b/wanvideo/modules/model.py
@@ -922,7 +922,7 @@ class WanAttentionBlock(nn.Module):
 
         if cross_attn_type != "no_cross_attn":
             self.norm3 = WanLayerNorm(out_features, eps, elementwise_affine=True) if cross_attn_norm else nn.Identity()
-            self.cross_attn = WAN_CROSSATTENTION_CLASSES[cross_attn_type](in_features, out_features, num_heads, qk_norm, eps, rms_norm_function=rms_norm_function,
+            self.cross_attn = WAN_CROSSATTENTION_CLASSES[cross_attn_type](in_features, out_features, num_heads, qk_norm, eps, attention_mode=self.attention_mode, rms_norm_function=rms_norm_function,
                                                                           head_norm=is_longcat)
         self.norm2 = WanLayerNorm(self.dim, eps)
 


### PR DESCRIPTION
It seems that the attention_mode parameter of WanModel-CrossAttn is not being passed in correctly, and the default value, `sdpa` is being used all the time.