### PR TITLE
Fix: fallback when SageAttention is unavailable (Windows support)

### DIFF
--- a/nodes_model_loading.py
+++ b/nodes_model_loading.py
@@ -1124,9 +1124,11 @@ class WanVideoModelLoader:
         if "sage" in attention_mode:
             try:
                 from sageattention import sageattn
-            except Exception as e:
-                raise ValueError(f"Can't import SageAttention: {str(e)}")
-
+                use_sageattn = True
+            except ImportError as e:
+                print(f"SageAttention is not available ->falling back to default attention: {e}")
+                use_sageattn = False
+                      
         gguf = False
         if model.endswith(".gguf"):
             if quantization != "disabled":


### PR DESCRIPTION
Fixes crash when SageAttention is not available (e.g. Windows without Triton). Falls back to default attention instead of raising error.