### PR TITLE
fix: return 3-tuple from predict_with_cfg use_zero_init early-exit

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -1176,7 +1176,7 @@ class WanVideoSampler:
             with torch.autocast(device_type=mm.get_autocast_device(device), dtype=dtype) if autocast_enabled else nullcontext():
 
                 if use_cfg_zero_star and (idx <= zero_star_steps) and use_zero_init:
-                    return z*0, None
+                    return z*0, None, cache_state
 
                 nonlocal patcher
                 current_step_percentage = idx / len(timesteps)


### PR DESCRIPTION
Fixes #2010.

The CFG-Zero* early-exit in `predict_with_cfg` returned a 2-tuple while every caller (and every other return in the same function) unpacks 3 values: `(noise_pred, noise_pred_ovi, cache_state)`. Workflows that enable both `cfg_zero_star` and `use_zero_init` on `WanVideoExperimentalArgs` crash on step 0 with:

```
ValueError: not enough values to unpack (expected 3, got 2)
```

Same shape of bug as #1454 (HUMO branch), different code path that escaped that fix.

## Change

```diff
 if use_cfg_zero_star and (idx <= zero_star_steps) and use_zero_init:
-    return z*0, None
+    return z*0, None, cache_state
```

`cache_state` is passed through unchanged — at the zero-init step there is no actual cache update to record, so returning the input cache state is the natural identity. I have been running this patch locally on a Wan 2.2 14B I2V workflow with `cfg_zero_star=true, use_zero_init=true` and it produces correct output (step 0 noise prediction is zeroed as the CFG-Zero* design intends, subsequent steps proceed normally).

## Test plan

- [x] Reproduced the crash on `main` with `WanVideoExperimentalArgs(cfg_zero_star=true, use_zero_init=true)` wired into `WanVideoSamplerv2.extra_args` via `WanVideoSamplerExtraArgs`.
- [x] Applied the patch and re-ran the same graph end-to-end without error.
- [x] Verified all other returns in `predict_with_cfg` are 3-tuples.
