### PR TITLE
fix(scheduler): reject step ranges that produce empty timestep slices

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -2753,6 +2753,28 @@ class WanVideoScheduler:
     CATEGORY = "WanVideoWrapper"
     EXPERIMENTAL = True
 
+    @classmethod
+    def VALIDATE_INPUTS(cls, steps, start_step, end_step, **kwargs):
+        # Run at prompt-queue time, before any node executes — this prevents
+        # an upstream sampler from loading the model and burning GPU time on
+        # work that a downstream sampler with an empty timestep slice will
+        # then crash on (UnboundLocalError: 'callback_latent' / 'noise_pred').
+        if start_step >= steps:
+            return (
+                f"start_step ({start_step}) must be < steps ({steps}); "
+                f"the requested range would produce an empty timestep slice "
+                f"and the sampler would crash mid-graph."
+            )
+        if end_step != -1:
+            if end_step > steps:
+                return f"end_step ({end_step}) must be <= steps ({steps})."
+            if end_step <= start_step:
+                return (
+                    f"end_step ({end_step}) must be > start_step ({start_step}); "
+                    f"the requested range would produce an empty timestep slice."
+                )
+        return True
+
     def process(self, scheduler, steps, start_step, end_step, shift, unique_id, sigmas=None, enhance_hf=False):
         sample_scheduler, timesteps, start_idx, end_idx = get_scheduler(
             scheduler, steps, start_step, end_step, shift, device, sigmas=sigmas, log_timesteps=True, enhance_hf=enhance_hf)

--- a/wanvideo/schedulers/__init__.py
+++ b/wanvideo/schedulers/__init__.py
@@ -174,8 +174,22 @@ def get_scheduler(scheduler, steps, start_step, end_step, shift, device, transfo
         sample_scheduler.sigmas = torch.cat([timesteps / 1000, torch.zeros(1, device=timesteps.device)])
 
     steps = len(timesteps)
+    # Reject ranges that produce an empty timestep slice — otherwise the
+    # sampler's main loop never executes and downstream code (e.g. callbacks
+    # referenced after the loop) crashes with a confusing UnboundLocalError.
+    if isinstance(start_step, int) and start_step >= steps:
+        raise ValueError(
+            f"start_step ({start_step}) must be < steps ({steps}); "
+            f"the requested range would produce an empty timestep slice"
+        )
+    if isinstance(end_step, int) and end_step != -1 and end_step > steps:
+        raise ValueError(
+            f"end_step ({end_step}) must be <= steps ({steps})"
+        )
     if (isinstance(start_step, int) and end_step != -1 and start_step >= end_step) or (not isinstance(start_step, int) and start_step != -1 and end_step >= start_step):
-        raise ValueError("start_step must be less than end_step")
+        raise ValueError(
+            f"start_step ({start_step}) must be less than end_step ({end_step})"
+        )
 
     # Determine start and end indices for slicing
     start_idx = 0


### PR DESCRIPTION
## Problem

A `WanVideoSchedulerv2` (or v1) configured with a step range that resolves to an empty `timesteps` slice — e.g. `steps=4, start_step=8, end_step=-1`, or `steps=8, end_step=12` — currently builds a scheduler with zero timesteps. The downstream sampler's main loop (`for idx, t in enumerate(timesteps[ttm_start_step:])`) never executes, and the post-loop `return` references variables that are only assigned inside the loop:

```
UnboundLocalError: cannot access local variable 'callback_latent'
where it is not associated with a value
```

(`callback_latent` is the most common offender on the v2 sampler return path; v1 hits the same class of error on `noise_pred`.)

This is especially painful for HIGH/LOW two-sampler chains: the HIGH sampler runs to completion — full model load, JIT compile, full step count — before the LOW sampler's broken scheduler builds and crashes. On a 14B Wan 2.2 model that's a couple of minutes of GPU time burned on work that was always going to be discarded.

A real-world misconfiguration that triggered this:

| node | scheduler | steps | shift | start_step | end_step |
|---|---|---|---|---|---|
| HIGH | dpm++_sde/beta | **4** | 8 | 0 | 4 |
| LOW  | dpm++_sde/beta | **4** | 8 | **8** | -1 |

LOW's `timesteps[8:]` on a length-4 sequence is `[]`. The HIGH branch ran 4 steps, fp8 compiled, then died on the LOW return.

## Why the existing check misses it

`get_scheduler()` already validates `start_step >= end_step`, but only when `end_step != -1`. The `end_step=-1` ("run to the end") path has no upper bound on `start_step`, so anything `>= len(timesteps)` slips through.

```python
# wanvideo/schedulers/__init__.py (before)
if (isinstance(start_step, int) and end_step != -1 and start_step >= end_step) or ...:
    raise ValueError("start_step must be less than end_step")
```

## Fix

Two layers, so the validation fires regardless of how the scheduler was constructed:

### 1. `get_scheduler()` — defensive check for any caller

Adds:
- `start_step >= steps` → reject
- `end_step > steps` (when `end_step != -1`) → reject
- Existing `start_step >= end_step` check kept and given a more informative message.

This protects callers that build a scheduler outside the public `WanVideoScheduler[v2]` node, and it covers the float-sigma-threshold path that the original check already handled.

### 2. `VALIDATE_INPUTS` on `WanVideoScheduler` — rejects at prompt-queue time

`VALIDATE_INPUTS` is ComfyUI's pre-execution hook: it runs before any node in the graph is invoked. So a misconfigured scheduler stops the whole prompt before HIGH loads the model, with a red error in the UI pointing directly at the offending node. No GPU time is consumed at all. `WanVideoSchedulerv2` inherits from `WanVideoScheduler` and picks up the check automatically.

```python
@classmethod
def VALIDATE_INPUTS(cls, steps, start_step, end_step, **kwargs):
    if start_step >= steps:
        return f"start_step ({start_step}) must be < steps ({steps}); ..."
    ...
```

## Error-message philosophy

Each failure message names all three values (`start_step`, `end_step`, `steps`) and explains the consequence. The original `"start_step must be less than end_step"` wasn't enough to map back to "I typo'd 8 for 4 in the LOW branch's start_step." The new messages let the user fix the widget without first having to reverse-engineer the symptom.

## What about auto-fixing?

Considered and rejected. `start=8, end=-1` on `steps=4` is ambiguous: the user might have meant `steps=8` total or `start=2` for a 4-step split — no way to tell. Refusing with a precise message is the right move; silent clamping would hide misconfigurations behind plausibly-shaped but unintended output.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` clean on both edited files.
- [x] Reproduce the original `callback_latent` UnboundLocalError on `main` with `WanVideoSchedulerv2(steps=4, start_step=8, end_step=-1)`.
- [x] Apply this branch — prompt is now rejected at queue time with `"start_step (8) must be < steps (4); the requested range would produce an empty timestep slice and the sampler would crash mid-graph."`
- [x] Valid configurations (`steps=8, start_step=4, end_step=-1`; `steps=12, start_step=7, end_step=10`; etc.) still validate and run.
- [x] Float-sigma threshold path (start/end as `float`) is unchanged — VALIDATE_INPUTS only sees the int widget values; `get_scheduler()` keeps the existing float branch.

## Related

This addresses the same class of "fail loudly, fail fast" gap that #2011 (`use_zero_init` early-exit returning a 2-tuple where the caller unpacks 3) targets — both bugs would have produced clearer symptoms with a guard one layer up. Happy to fold both into a single PR if that's preferred.