### PR TITLE
Update num_frames output for LongCatAvatarWhisperEmbeds

### DIFF
--- a/LongCat/nodes.py
+++ b/LongCat/nodes.py
@@ -311,12 +311,12 @@ class LongCatAvatarWhisperEmbeds:
             actual_num_frames = min(num_frames, actual_frames_from_audio)
             
             if actual_frames_from_audio < num_frames:
-                log.info(f"[MultiTalk] Audio duration ({actual_frames_from_audio} frames) is shorter than requested ({num_frames} frames). Using {actual_num_frames} frames.")
+                log.info(f"[LongCat] Audio duration ({actual_frames_from_audio} frames) is shorter than requested ({num_frames} frames). Using {actual_num_frames} frames.")
 
         # Debug: log final mixed audio length and mode
         total_samples_raw = sum([ao["waveform"].shape[-1] for ao in audio_outputs])
-        log.info(f"[MultiTalk] total raw duration = {total_samples_raw/sr:.3f}s")
-        log.info(f"[MultiTalk] multi_audio_type={multi_audio_type} | final waveform shape={out_audio['waveform'].shape} | length={out_audio['waveform'].shape[-1]} samples | seconds={out_audio['waveform'].shape[-1]/sr:.3f}s (expected {'sum' if multi_audio_type=='add' else 'max'} of raw)")
+        log.info(f"[LongCat] total raw duration = {total_samples_raw/sr:.3f}s")
+        log.info(f"[LongCat] multi_audio_type={multi_audio_type} | final waveform shape={out_audio['waveform'].shape} | length={out_audio['waveform'].shape[-1]} samples | seconds={out_audio['waveform'].shape[-1]/sr:.3f}s (expected {'sum' if multi_audio_type=='add' else 'max'} of raw)")
 
 
         return (multitalk_embeds, out_audio, actual_num_frames)

--- a/LongCat/nodes.py
+++ b/LongCat/nodes.py
@@ -295,7 +295,31 @@ class LongCatAvatarWhisperEmbeds:
                 offset += w.shape[-1]
             out_audio = {"waveform": mixed, "sample_rate": sr}
 
-        return (multitalk_embeds, out_audio, num_frames)
+        # Calculate actual frames based on audio duration
+        actual_num_frames = num_frames
+        if len(audio_outputs) > 0:
+            if multi_audio_type == "para":
+                # For parallel mode, use the longest audio duration
+                max_audio_duration = max([ao["waveform"].shape[-1] / sr for ao in audio_outputs])
+                actual_frames_from_audio = int(max_audio_duration * fps)
+            else:  # "add"
+                # For sequential mode, use the total audio duration
+                total_audio_duration = sum([ao["waveform"].shape[-1] / sr for ao in audio_outputs])
+                actual_frames_from_audio = int(total_audio_duration * fps)
+            
+            # Use the smaller of requested frames or actual audio frames
+            actual_num_frames = min(num_frames, actual_frames_from_audio)
+            
+            if actual_frames_from_audio < num_frames:
+                log.info(f"[MultiTalk] Audio duration ({actual_frames_from_audio} frames) is shorter than requested ({num_frames} frames). Using {actual_num_frames} frames.")
+
+        # Debug: log final mixed audio length and mode
+        total_samples_raw = sum([ao["waveform"].shape[-1] for ao in audio_outputs])
+        log.info(f"[MultiTalk] total raw duration = {total_samples_raw/sr:.3f}s")
+        log.info(f"[MultiTalk] multi_audio_type={multi_audio_type} | final waveform shape={out_audio['waveform'].shape} | length={out_audio['waveform'].shape[-1]} samples | seconds={out_audio['waveform'].shape[-1]/sr:.3f}s (expected {'sum' if multi_audio_type=='add' else 'max'} of raw)")
+
+
+        return (multitalk_embeds, out_audio, actual_num_frames)
 
 
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
LongCatAvatarWhisperEmbeds was outputting num_frames exactly as the input regardless of whether the audio was long enough or not. 

This change makes it behave just like MultiTalkWav2VecEmbeds by calculating the actual frames based on audio duration.