### PR TITLE
Fix GGUF reload race causing heap corruption on Apple Silicon

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -126,8 +126,19 @@ class WanVideoSampler:
                          block_swap_args=block_swap_args, compile_args=model["compile_args"])
 
         if gguf_reader is not None: #handle GGUF
-            load_weights(transformer, patcher.model["sd"], base_dtype=dtype, transformer_load_device=device, patcher=patcher, gguf=True,
-                         reader=gguf_reader, block_swap_args=block_swap_args, compile_args=model["compile_args"])
+            # Skip GGUF reload after the first call to avoid heap corruption on
+            # Apple Silicon (MPS): repeatedly re-reading the multi-GB GGUF blob
+            # races MPS async frees against CPU allocations in unified memory
+            # and triggers BUG IN CLIENT OF LIBMALLOC on the 2nd render onward.
+            # Set WANVIDEO_DISABLE_GGUF_RELOAD_GUARD=1 to restore the original
+            # behaviour (needed for mid-process LoRA hot-swap).
+            _gguf_reload_guard = (
+                os.environ.get("WANVIDEO_DISABLE_GGUF_RELOAD_GUARD", "0") != "1"
+            )
+            if not _gguf_reload_guard or not getattr(transformer, "_gguf_weights_loaded", False):
+                load_weights(transformer, patcher.model["sd"], base_dtype=dtype, transformer_load_device=device, patcher=patcher, gguf=True,
+                             reader=gguf_reader, block_swap_args=block_swap_args, compile_args=model["compile_args"])
+                transformer._gguf_weights_loaded = True
             set_lora_params_gguf(transformer, patcher.patches)
             transformer.patched_linear = True
         elif len(patcher.patches) != 0: #handle patched linear layers (unmerged loras, fp8 scaled)


### PR DESCRIPTION
## Problem

On Apple Silicon (MPS), rendering 2+ scenes back-to-back in a single
ComfyUI process with a GGUF-quantised WanVideo model crashes the whole
process with `BUG IN CLIENT OF LIBMALLOC: memory corruption of free
block` / `EXC_BREAKPOINT (SIGTRAP)`. The first render always succeeds;
the second fails reliably. The only known workaround was a full ComfyUI
restart between scenes (30–60 s overhead per transition).

## Root cause

`WanVideoSampler.process()` calls `load_weights()` unconditionally on
every prompt (`nodes_sampler.py:128-131`). For GGUF this re-reads the
full 14.8 GB tensor blob and rebinds module parameters. On MPS, async
device frees race against CPU-side allocations in unified memory and
corrupt a libmalloc free-block header.

## Fix

Guard the GGUF reload with a one-shot flag on the transformer object,
matching the existing per-transformer state pattern (`patched_linear`,
`blocks_to_swap`, …). Set `WANVIDEO_DISABLE_GGUF_RELOAD_GUARD=1` to
restore the original behaviour for LoRA hot-swap scenarios.

```python
if gguf_reader is not None: #handle GGUF
    if not getattr(transformer, "_gguf_weights_loaded", False) or \
       os.environ.get("WANVIDEO_DISABLE_GGUF_RELOAD_GUARD") == "1":
        load_weights(transformer, ...)
        transformer._gguf_weights_loaded = True
    set_lora_params_gguf(transformer, patcher.patches)
    transformer.patched_linear = True
```

The second `load_weights()` call site at line ~2367 is already gated by
`if offloaded:` and is untouched. CUDA is unaffected (separate VRAM
arena, no race).

## Testing

| | |
|---|---|
| Device | Apple M4 Pro, 48 GB unified memory |
| OS / Python / torch | macOS 25.5 / 3.12.13 / 2.7.1 (MPS) |
| Model | Wan2.2-I2V-A14B GGUF Q5_K_M, high + low noise |
| Before | scene 2 crashes during `load_weights()`, reproduces every time |
| After | 11 sequential scenes in one process, zero crashes, output bit-identical to single-scene baseline |

Happy to share the crash report `.ips`, full ComfyUI log of the
successful run, or a reproducer workflow on request.
