### PR TITLE
fix: return correct tuple size from predict_with_cfg zero-init early-exit

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -1182,7 +1182,7 @@ class WanVideoSampler:
             with torch.autocast(device_type=mm.get_autocast_device(device), dtype=dtype) if autocast_enabled else nullcontext():
 
                 if use_cfg_zero_star and (idx <= zero_star_steps) and use_zero_init:
-                    return z*0, None
+                    return z*0, None, cache_state
 
                 nonlocal patcher
                 current_step_percentage = idx / len(timesteps)

--- a/skyreels/nodes.py
+++ b/skyreels/nodes.py
@@ -457,7 +457,7 @@ class WanVideoDiffusionForcingSampler:
             with torch.autocast(device_type=mm.get_autocast_device(device), dtype=dtype, enabled=("fp8" in model["quantization"])):
 
                 if use_cfg_zero_star and (idx <= zero_star_steps) and use_zero_init:
-                    return latent_model_input*0, None
+                    return latent_model_input*0, teacache_state
 
                 nonlocal patcher
                 current_step_percentage = idx / len(init_timesteps)


### PR DESCRIPTION
## Summary

- Fixes the `ValueError: not enough values to unpack (expected 3, got 2)` crash when both `cfg_zero_star` and `use_zero_init` are enabled in `WanVideoExperimentalArgs`
- Passes through `cache_state`/`teacache_state` unchanged in the zero-init early-exit path — at step 0 there is no cache update, so returning the input state is the correct identity behavior
- Fixes the same bug in both `nodes_sampler.py` (3-tuple callers) and `skyreels/nodes.py` (2-tuple callers where `None` was returned instead of state)

## Changes

**`nodes_sampler.py` (line 1185):**
```diff
 if use_cfg_zero_star and (idx <= zero_star_steps) and use_zero_init:
-    return z*0, None
+    return z*0, None, cache_state
```

**`skyreels/nodes.py` (line 460):**
```diff
 if use_cfg_zero_star and (idx <= zero_star_steps) and use_zero_init:
-    return latent_model_input*0, None
+    return latent_model_input*0, teacache_state
```

## Test plan

- [x] Verified the fix matches the return signature of all other return paths in both functions
- [x] Confirmed all callers in `nodes_sampler.py` unpack 3 values and all callers in `skyreels/nodes.py` unpack 2 values
- [ ] Test with Wan 2.2 I2V/T2V workflow with `cfg_zero_star=True` + `use_zero_init=True`

Fixes #2010