### PR TITLE
Fix UnboundLocalError: multitalk_audio_stride referenced before assignment in WanVideoSampler

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -564,6 +564,7 @@ class WanVideoSampler:
 
         # MultiTalk
         multitalk_audio_embeds = audio_emb_slice = audio_features_in = None
+        multitalk_audio_stride = None
         multitalk_embeds = image_embeds.get("multitalk_embeds", multitalk_embeds)
 
         if multitalk_embeds is not None:


### PR DESCRIPTION
## Problem

`WanVideoSampler` raises an `UnboundLocalError` on any run that does **not** pass `multitalk_embeds` (i.e. the large majority of workflows — standard T2V/I2V, VACE, Fun-Control, etc.):

```
UnboundLocalError: cannot access local variable 'multitalk_audio_stride' where it is not associated with a value
  File "custom_nodes/ComfyUI-WanVideoWrapper/nodes_sampler.py", line 822, in process
    if multitalk_audio_stride is not None:
```

## Root cause

`multitalk_audio_stride` is only bound inside the `if multitalk_embeds is not None:` branch:

```python
multitalk_audio_stride = multitalk_embeds.get("audio_stride", None)
```

but it is later read unconditionally:

```python
if multitalk_audio_stride is not None:
    audio_stride = multitalk_audio_stride
```

When `multitalk_embeds` is `None`, the name is never assigned, so the later read throws.

## Fix

Initialize `multitalk_audio_stride = None` alongside the other MultiTalk locals (`multitalk_audio_embeds`, `audio_emb_slice`, `audio_features_in`), so the unconditional read is always safe. One line, no behavior change for the MultiTalk path.

## Reproduction

Run any VACE / T2V / I2V workflow through `WanVideoSampler` without a MultiTalk embed connected → error before this patch, works after.
