### PR TITLE
fix: remove debug print crashing on None audio_emb_slice

### DIFF
--- a/nodes_sampler.py
+++ b/nodes_sampler.py
@@ -638,7 +638,6 @@ class WanVideoSampler:
 
         if multitalk_embeds is not None:
             audio_emb_slice = multitalk_embeds.get("audio_emb_slice", None) # if already sliced
-            print("audio_emb_slice:", audio_emb_slice.shape)
             # Handle single or multiple speaker embeddings
             if audio_emb_slice is None:
                 audio_features_in = multitalk_embeds.get("audio_features", None)


### PR DESCRIPTION
Running any InfiniteTalk / MultiTalk audio-driven workflow on the `longcat_avatar` branch crashes in `WanVideoSampler`:

```
'NoneType' object has no attribute 'shape'
  File ".../nodes_sampler.py", line 641, in process
    print("audio_emb_slice:", audio_emb_slice.shape)
```

A leftover debug `print` calls `.shape` on `audio_emb_slice` immediately after it is set to `multitalk_embeds.get("audio_emb_slice", None)`. `None` is the normal path — `multitalk_embeds` carries `audio_features` and the slice is computed downstream — so the print throws on every run.

**Fix:** remove the debug line. The existing `if audio_emb_slice is None:` block already handles that case.

Verified on `longcat_avatar` with an image+audio InfiniteTalk workflow: the sampler proceeds past this point after removing the line.