### PR TITLE
fix: materialize weights before VRAM-management wrapping (#1596)

### DIFF
--- a/diffsynth/vram_management/layers.py
+++ b/diffsynth/vram_management/layers.py
@@ -30,12 +30,30 @@ class AutoWrappedModule(torch.nn.Module):
             self.module.to(dtype=self.onload_dtype, device=self.onload_device)
             self.state = 1
 
+    def __getattr__(self, name: str):
+        # Proxy attribute access to the wrapped module so that model code that
+        # directly accesses e.g. `norm_layer.weight.dtype` on an AutoWrappedModule
+        # (for dtype-cast purposes) still works.
+        # nn.Module.__getattr__ is only called when the standard lookup fails,
+        # so this doesn't interfere with 'module', 'offload_device', etc.
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            if name == 'module':
+                raise  # guard against recursion before self.module is set
+            return getattr(self.module, name)
+
     def forward(self, *args, **kwargs):
-        if self.onload_dtype == self.computation_dtype and self.onload_device == self.computation_device:
-            module = self.module
-        else:
-            module = copy.deepcopy(self.module).to(dtype=self.computation_dtype, device=self.computation_device)
-        return module(*args, **kwargs)
+        # Always ensure the inner module is on the compute device before running.
+        # Original code used 'module = self.module' (no cast) when
+        # onload_device == computation_device, but that assumption breaks when
+        # weights are CPU-resident (loaded via load_weights to offload_device).
+        # Using in-place .to() avoids the expensive deepcopy and is correct
+        # regardless of where self.module was loaded.
+        self.module.to(dtype=self.computation_dtype, device=self.computation_device)
+        output = self.module(*args, **kwargs)
+        self.module.to(dtype=self.offload_dtype, device=self.offload_device)
+        return output
     
 
 class AutoWrappedLinear(torch.nn.Linear):

--- a/nodes_model_loading.py
+++ b/nodes_model_loading.py
@@ -1766,6 +1766,14 @@ class WanVideoModelLoader:
         if vram_management_args is not None:
             if gguf:
                 raise ValueError("GGUF models don't support vram management")
+            # Transformer was created with init_empty_weights() (meta device).
+            # For the no-lora / no-scaled-quant path, load_weights() has not been
+            # called yet, so all parameters are still meta tensors.
+            # enable_vram_management wraps each module with AutoWrappedModule/Linear
+            # which calls module.to(device) — that fails on meta tensors.
+            # Fix: materialise weights from sd before wrapping.
+            if sd is not None:
+                load_weights(transformer, sd, weight_dtype, base_dtype, transformer_load_device)
             from .diffsynth.vram_management import enable_vram_management, AutoWrappedModule, AutoWrappedLinear
             from .wanvideo.modules.model import WanLayerNorm
 
@@ -1790,7 +1798,15 @@ class WanVideoModelLoader:
                     offload_dtype=weight_dtype,
                     offload_device=offload_device,
                     onload_dtype=weight_dtype,
-                    onload_device=device,
+                    # Use offload_device here (not device/CUDA).
+                    # When onload_device == computation_device, AutoWrappedModule /
+                    # AutoWrappedLinear assume weights are already on onload_device
+                    # and use them directly — but our weights are on CPU (loaded via
+                    # load_weights to offload_device).  Setting onload_device = CPU
+                    # makes onload_device != computation_device, which routes forward
+                    # through the cast path (cast_to / in-place .to()), correctly
+                    # moving weights to CUDA on demand.
+                    onload_device=offload_device,
                     computation_dtype=base_dtype,
                     computation_device=device,
                 ),
@@ -1805,6 +1821,37 @@ class WanVideoModelLoader:
                 ),
                 compile_args = compile_args,
             )
+            # After wrapping, AutoWrapped* modules handle CPU↔GPU casts in
+            # forward (with the fixed layers.py).  But two categories of params
+            # are NOT wrapped and stay on CPU:
+            # 1. Raw nn.Parameter directly on blocks (e.g. self.modulation on
+            #    WanAttentionBlock) — these are added to e on CUDA → mismatch.
+            # 2. Modules explicitly excluded from wrapping by layers.py line 78:
+            #    patch_embedding, vace_patch_embedding, rope_embedder, emb_pos.
+            # Fix: find every param inside an AutoWrapped* module (those are
+            # handled by forward), then move all others to the compute device.
+            wrapped_param_ids: set = set()
+            for mod in patcher.model.diffusion_model.modules():
+                if isinstance(mod, AutoWrappedLinear):
+                    if mod.weight is not None:
+                        wrapped_param_ids.add(id(mod.weight))
+                    if mod.bias is not None:
+                        wrapped_param_ids.add(id(mod.bias))
+                elif isinstance(mod, AutoWrappedModule):
+                    for p in mod.module.parameters():
+                        wrapped_param_ids.add(id(p))
+            log.info("Moving non-AutoWrapped params (modulation, patch_embedding, …) to compute device…")
+            for n, p in patcher.model.diffusion_model.named_parameters():
+                if id(p) not in wrapped_param_ids and p.device.type != "cuda":
+                    p.data = p.data.to(device=device)
+            # Weights are managed: AutoWrapped* modules cast CPU→GPU in forward,
+            # non-wrapped params are now on CUDA.
+            # Clear sd so the sampler's load_weights call (which iterates
+            # named_parameters after wrapping, where names include '.module.')
+            # doesn't KeyError on renamed keys.
+            sd = None
+            gc.collect()
+            mm.soft_empty_cache()
 
         if merge_loras and lora is not None:
             # Skip offloading if load_device is main_device (for unified memory systems like AMD Strix Halo)


### PR DESCRIPTION
**Fixes #1596** — and the same root cause behind #843 / #1188 (related: #409, #506).

## The bug
Enabling the **WanVideoVRAMManagement** node crashes model loading with
`Cannot copy out of meta tensor; no data!`.

## Root cause
The transformer is built with `init_empty_weights()`, so every parameter starts on
the **meta** device. On the **no-lora / no-scaled-quant** path (e.g. a plain
Wan2.1-VACE workflow), `load_weights()` is *not* called before the vram block —
neither the `lora is not None and merge_loras` branch nor the
`"scaled" in quantization or lora is not None` branch runs — so the parameters are
**still meta tensors** when `enable_vram_management` executes.

`enable_vram_management` wraps each `norm` / `Conv3d` / `LayerNorm` in
`AutoWrappedModule`, whose `__init__` does:

```python
self.module = module.to(dtype=offload_dtype, device=offload_device)
```

Calling `.to()` to move a **meta** tensor raises
`NotImplementedError: Cannot copy out of meta tensor; no data!`. The crash is in the
**wrapper construction**, before any weight lookup — not in an `sd[name]` miss.

Observed traceback (live, on this stack):

```
File "nodes_model_loading.py", line 1768, in loadmodel
    enable_vram_management( ... )
File "diffsynth/vram_management/layers.py", line 92, in enable_vram_management_recursively
    module_ = target_module(module, **module_config_)
File "diffsynth/vram_management/layers.py", line 14, in __init__
    self.module = module.to(dtype=offload_dtype, device=offload_device)
...
NotImplementedError: Cannot copy out of meta tensor; no data!
```

## The fix
**`nodes_model_loading.py`**
1. **Materialize before wrapping** — in the vram block, call `load_weights(...)` to
   fill the meta tensors from `sd` *before* `enable_vram_management`, so it wraps
   real (non-meta) modules. This is what removes the crash.
2. **`onload_device=offload_device`** (was `=device`) in `module_config`. With
   CPU-resident weights, keeping `onload_device == computation_device` makes the
   wrappers assume weights are already on the compute device; setting it to the
   offload (CPU) device makes `onload_device != computation_device`, which routes
   `forward` through the cast path that moves weights to CUDA on demand.
3. **Place the non-wrapped params** — params that `enable_vram_management` does *not*
   wrap (raw `nn.Parameter` like block `modulation`, and excluded modules such as
   `patch_embedding`/`rope_embedder`) stay on CPU and would mismatch CUDA tensors in
   the forward pass; move them to the compute device. Then clear `sd` so a later
   `load_weights` over the now-renamed `.module.` param names can't `KeyError`.

**`diffsynth/vram_management/layers.py`**
4. `AutoWrappedModule.__getattr__` proxy so model code that reaches the wrapped
   module's attributes (e.g. `norm_layer.weight.dtype`) through the wrapper still
   works.
5. `AutoWrappedModule.forward` moves the inner module to the compute device for the
   call and back to the offload device afterwards (no `deepcopy`), which is correct
   regardless of where the weights were loaded.

## Validation
End-to-end on a Wan2.1-VACE workflow (`wan2.1_vace_14B_fp16`, base precision `fp16`,
quantization `disabled`, **no lora**) with **WanVideoVRAMManagement** (offload 0.9):

- **Before** (upstream `main`): crash at `enable_vram_management` →
  `Cannot copy out of meta tensor; no data!` (full traceback above; captured live
  by forcing the loader to run in isolation).
- **After** (this branch): `Transformer weights loaded`, the VACE edit completes
  (~490–520 s/clip on an RTX 5090, well under 32 GB).

A CPU-only mechanism check (`verify_1596.py`) reproduces the meta-tensor crash on a
wrapped meta module and confirms that materializing first lets `enable_vram_management`
succeed, plus the `__getattr__` proxy and the device-routed `forward`.

## Scope / alternatives
The `.module.`-name `KeyError` some reports mention is a *secondary* symptom (it only
occurs when `load_weights` runs *after* wrapping, over renamed params); this PR
sidesteps it by materializing before wrapping and clearing `sd`. Stripping the
`.module.` infix in `load_weights` is a viable complementary hardening but is not
required once weights are materialized up front.

---
*Disclosure: drafted and validated with AI assistance (Claude); reviewed and
submitted by me. The commit carries a `Co-Authored-By` trailer.*
