### PR TITLE
fix: stream Wan VAE decode output to CPU

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2146,7 +2146,25 @@ class WanVideoDecode:
             images = images.permute(1, 2, 3, 0).cpu().float()
             return (images,)
         else:
-            images = vae.decode(latents, device=device, end_=(end_image is not None), tiled=enable_vae_tiling, tile_size=(tile_x//8, tile_y//8), tile_stride=(tile_stride_x//8, tile_stride_y//8))[0]
+            stream_to_cpu = (
+                not enable_vae_tiling
+                and end_image is None
+                and type(getattr(vae, "model", None)).__name__ == "VideoVAE_"
+            )
+            decode_kwargs = (
+                {"output_device": "cpu", "output_dtype": torch.float32}
+                if stream_to_cpu
+                else {}
+            )
+            images = vae.decode(
+                latents,
+                device=device,
+                end_=(end_image is not None),
+                tiled=enable_vae_tiling,
+                tile_size=(tile_x//8, tile_y//8),
+                tile_stride=(tile_stride_x//8, tile_stride_y//8),
+                **decode_kwargs,
+            )[0]
 
 
         images = images.cpu().float()
@@ -2160,7 +2178,15 @@ class WanVideoDecode:
 
         if is_looped:
             temp_latents = torch.cat([latents[:, :, -3:]] + [latents[:, :, :2]], dim=2)
-            temp_images = vae.decode(temp_latents, device=device, end_=(end_image is not None), tiled=enable_vae_tiling, tile_size=(tile_x//vae.upsampling_factor, tile_y//vae.upsampling_factor), tile_stride=(tile_stride_x//vae.upsampling_factor, tile_stride_y//vae.upsampling_factor))[0]
+            temp_images = vae.decode(
+                temp_latents,
+                device=device,
+                end_=(end_image is not None),
+                tiled=enable_vae_tiling,
+                tile_size=(tile_x//vae.upsampling_factor, tile_y//vae.upsampling_factor),
+                tile_stride=(tile_stride_x//vae.upsampling_factor, tile_stride_y//vae.upsampling_factor),
+                **decode_kwargs,
+            )[0]
             temp_images = temp_images.cpu().float()
             temp_images = (temp_images - temp_images.min()) / (temp_images.max() - temp_images.min())
             images = torch.cat([temp_images[:, 9:].to(images), images[:, 5:]], dim=1)

--- a/wanvideo/wan_video_vae.py
+++ b/wanvideo/wan_video_vae.py
@@ -1128,7 +1128,7 @@ class VideoVAE_(nn.Module):
 
 
 
-    def decode(self, z, pbar=True):
+    def decode(self, z, pbar=True, output_device=None, output_dtype=None):
         # z: [b,c,t,h,w]
         z = z / self.inv_std.to(z) + self.mean.to(z)
         input_shape = z.shape
@@ -1140,22 +1140,50 @@ class VideoVAE_(nn.Module):
         except Exception:
             pass
         x = self.conv2(z)
+        out = None
+        out_offset = 0
+        temporal_factor = 2 ** sum(self.temperal_upsample)
         for i in tqdm(range(iter_), desc="WanVAE decoding frames", disable=not pbar):
             self._conv_idx = [0]
-            if i == 0:
-                out = self.decoder(x[:, :, i:i + 1, :, :],
-                                   feat_cache=self._feat_map,
-                                   feat_idx=self._conv_idx)
+            out_chunk = self.decoder(x[:, :, i:i + 1, :, :],
+                                     feat_cache=self._feat_map,
+                                     feat_idx=self._conv_idx)
+            if output_device is None:
+                if out is None:
+                    out = out_chunk
+                else:
+                    out = torch.cat([out, out_chunk], 2)
             else:
-                out_ = self.decoder(x[:, :, i:i + 1, :, :],
-                                    feat_cache=self._feat_map,
-                                    feat_idx=self._conv_idx)
-                out = torch.cat([out, out_], 2)
+                if out is None:
+                    output_frames = (
+                        out_chunk.shape[2] + (iter_ - 1) * temporal_factor
+                    )
+                    out = torch.empty(
+                        (
+                            out_chunk.shape[0],
+                            out_chunk.shape[1],
+                            output_frames,
+                            out_chunk.shape[3],
+                            out_chunk.shape[4],
+                        ),
+                        device=output_device,
+                        dtype=(
+                            output_dtype
+                            if output_dtype is not None
+                            else out_chunk.dtype
+                        ),
+                    )
+                next_offset = out_offset + out_chunk.shape[2]
+                out[:, :, out_offset:next_offset].copy_(out_chunk)
+                out_offset = next_offset
+                del out_chunk
 
             if pbar:
                 pbar.update(1)
         if pbar:
             pbar.update_absolute(0)
+        if output_device is not None and out_offset != out.shape[2]:
+            raise RuntimeError("WanVAE decoder produced an incomplete output")
         self.clear_cache()
         if self.verbose:
             try:
@@ -1366,9 +1394,24 @@ class WanVideoVAE(nn.Module):
         x = self.model.encode(video, pbar=pbar, sample=sample)
         return x.float()
 
-    def single_decode(self, hidden_state, device, pbar=True):
+    def single_decode(
+        self,
+        hidden_state,
+        device,
+        pbar=True,
+        output_device=None,
+        output_dtype=None,
+    ):
         hidden_state = hidden_state.to(device)
-        video = self.model.decode(hidden_state, pbar=pbar)
+        if output_device is None or type(self.model) is not VideoVAE_:
+            video = self.model.decode(hidden_state, pbar=pbar)
+        else:
+            video = self.model.decode(
+                hidden_state,
+                pbar=pbar,
+                output_device=output_device,
+                output_dtype=output_dtype,
+            )
         return video
 
     def double_encode(self, video, device, pbar=True, sample=False):
@@ -1402,7 +1445,18 @@ class WanVideoVAE(nn.Module):
         return hidden_states
 
 
-    def decode(self, hidden_states, device, tiled=False, end_=False, tile_size=(34, 34), tile_stride=(18, 16), pbar=True):
+    def decode(
+        self,
+        hidden_states,
+        device,
+        tiled=False,
+        end_=False,
+        tile_size=(34, 34),
+        tile_stride=(18, 16),
+        pbar=True,
+        output_device=None,
+        output_dtype=None,
+    ):
         self.model.clear_cache()
         hidden_states = [hidden_state.to("cpu") for hidden_state in hidden_states]
         videos = []
@@ -1414,7 +1468,13 @@ class WanVideoVAE(nn.Module):
                 if end_:
                     video = self.double_decode(hidden_state, device)
                 else:
-                    video = self.single_decode(hidden_state, device, pbar=pbar)
+                    video = self.single_decode(
+                        hidden_state,
+                        device,
+                        pbar=pbar,
+                        output_device=output_device,
+                        output_dtype=output_dtype,
+                    )
             video = video.squeeze(0)
             videos.append(video)
         return videos


### PR DESCRIPTION
## Summary

- stream standard non-tiled Wan 2.1 VAE output into a preallocated CPU float32 tensor
- remove the growing GPU temporal concatenation used by the ComfyUI decode node
- preserve existing GPU-return, tiled, end-frame, 38-channel, and external VAE paths

Fixes #1826.

## Why

`VideoVAE_.decode()` currently grows the complete decoded tensor with
`torch.cat()` at every latent timestep. The node then immediately transfers the
completed result to CPU float32. For long videos, the repeated GPU accumulation
can exhaust VRAM after sampling has already completed.

This change allocates the final host tensor once and copies each decoded temporal
chunk directly into its final slice. The decoder cache sequence and default
GPU-return behavior are unchanged.

## Validation

[Autoresearch trace](https://dashboard.weco.ai/share/Nd1N52-Hlb_APok8P4YfAdoLoHD-DfMf)

The source-hashed evaluator uses current main
`088128b224242e110d3906c6750e9a3a348a659b`, verifies the downloaded
`Wan2_1_VAE_bf16.safetensors` SHA-256, and runs the public
`WanVideoVAE.decode()` path with fixed-seed latents.

| Output frames | Current main peak CUDA allocation | Candidate | Temporal cat output | Wall time |
| ---: | ---: | ---: | ---: | ---: |
| 81 | 3,389,870,592 B | 3,240,571,392 B | 1,585,152,000 B -> 0 B | 4,569 ms -> 3,774 ms |
| 321 | 3,860,316,672 B | 3,268,649,472 B | 24,035,328,000 B -> 0 B | 15,793 ms -> 14,905 ms |

For both comparison sizes:

- streamed output is byte-identical to current main (`max_abs_error = 0`)
- the candidate's default GPU-return path is also byte-identical and retains its existing behavior
- node dispatch preserves legacy/external decode signatures

The candidate also completed the issue-sized 3,497-frame decode with shape
`[1, 3, 3497, 480, 640]`, zero temporal cats, and a 3,633,374,208-byte peak CUDA
allocation delta. The final CPU output is 12.89 GB and process RSS reached 19.00
GB, so this addresses VRAM accumulation rather than total host-memory usage.
